### PR TITLE
Fix purchase price field to retain zero values

### DIFF
--- a/src/views/firearms/_form.ejs
+++ b/src/views/firearms/_form.ejs
@@ -25,7 +25,7 @@
 </div>
 <div>
   <label>Purchase Price
-    <input type="number" step="0.01" name="purchase_price" value="<%= item.purchase_price || '' %>">
+    <input type="number" step="0.01" name="purchase_price" value="<%= item.purchase_price ?? '' %>">
   </label>
 </div>
 <div>


### PR DESCRIPTION
## Summary
- ensure the firearm form keeps a zero purchase price when editing by avoiding falsy string coercion

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6903ed476b7c8332b9047ff9273274b8