### PR TITLE
Add user database and invitation-based registration

### DIFF
--- a/src/db/users.js
+++ b/src/db/users.js
@@ -1,0 +1,92 @@
+const crypto = require('crypto');
+const { db } = require('../db');
+
+const findByIdStmt = db.prepare('SELECT * FROM users WHERE id = ?');
+const findByUsernameStmt = db.prepare('SELECT * FROM users WHERE username = ?');
+const insertUserStmt = db.prepare(
+  'INSERT INTO users (username, password_hash, invited_by) VALUES (@username, @password_hash, @invited_by)'
+);
+const touchUserStmt = db.prepare("UPDATE users SET updated_at = datetime('now') WHERE id = ?");
+
+const findInviteByTokenStmt = db.prepare(
+  `SELECT ui.*, inviter.username AS inviter_username
+   FROM user_invites ui
+   LEFT JOIN users inviter ON inviter.id = ui.invited_by
+   WHERE ui.token = ?`
+);
+const insertInviteStmt = db.prepare(
+  'INSERT INTO user_invites (token, email, invited_by, expires_at) VALUES (@token, @email, @invited_by, @expires_at)'
+);
+const markInviteAcceptedStmt = db.prepare(
+  "UPDATE user_invites SET accepted_at = datetime('now'), accepted_user_id = @user_id WHERE id = @id"
+);
+
+function toSafeUser(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    username: row.username,
+    invitedBy: row.invited_by,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+function findById(id) {
+  const row = findByIdStmt.get(id);
+  return row ? { ...row } : null;
+}
+
+function findByUsername(username) {
+  const row = findByUsernameStmt.get(username);
+  return row ? { ...row } : null;
+}
+
+function create({ username, passwordHash, invitedBy = null }) {
+  const info = insertUserStmt.run({ username, password_hash: passwordHash, invited_by: invitedBy });
+  touchUserStmt.run(info.lastInsertRowid);
+  return toSafeUser(findByIdStmt.get(info.lastInsertRowid));
+}
+
+function createInvite({ email = null, invitedBy = null, expiresAt = null } = {}) {
+  const token = crypto.randomBytes(24).toString('hex');
+  insertInviteStmt.run({ token, email, invited_by: invitedBy, expires_at: expiresAt });
+  return findInviteByToken(token);
+}
+
+function findInviteByToken(token) {
+  const row = findInviteByTokenStmt.get(token);
+  return row ? { ...row } : null;
+}
+
+const acceptInvite = db.transaction(({ token, username, passwordHash }) => {
+  const invite = findInviteByToken(token);
+  if (!invite) throw new Error('Invite not found');
+  if (invite.accepted_at) throw new Error('Invite already used');
+  if (invite.expires_at) {
+    const expiresAt = new Date(invite.expires_at);
+    if (!Number.isNaN(expiresAt.getTime()) && expiresAt < new Date()) {
+      throw new Error('Invite expired');
+    }
+  }
+  if (findByUsername(username)) throw new Error('Username already taken');
+
+  const safeUser = create({ username, passwordHash, invitedBy: invite.invited_by });
+  markInviteAcceptedStmt.run({ id: invite.id, user_id: safeUser.id });
+  return {
+    user: safeUser,
+    invite: { ...invite, accepted_at: new Date().toISOString(), accepted_user_id: safeUser.id }
+  };
+});
+
+module.exports = {
+  findById,
+  findByUsername,
+  create,
+  toSafeUser,
+  invites: {
+    create: createInvite,
+    findByToken: findInviteByToken,
+    accept: acceptInvite
+  }
+};

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,7 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const bcrypt = require('bcryptjs');
-const { adminUser, adminPasswordHash } = require('../config');
+const { requireAuth } = require('../middleware/auth');
+const users = require('../db/users');
 const { loginLimiter } = require('../middleware/rateLimiter');
 
 router.get('/login', (req, res) => {
@@ -11,9 +12,9 @@ router.get('/login', (req, res) => {
 
 router.post('/login', loginLimiter, (req, res) => {
   const { username, password } = req.body;
-  // Use bcrypt to compare the password with the stored hash
-  if (username === adminUser && bcrypt.compareSync(password, adminPasswordHash)) {
-    req.session.user = { username };
+  const user = users.findByUsername(username);
+  if (user && bcrypt.compareSync(password, user.password_hash)) {
+    req.session.user = users.toSafeUser(user);
     return res.redirect('/');
   }
   // Log failed login attempt
@@ -29,6 +30,171 @@ router.post('/logout', (req, res) => {
   req.session.destroy(() => {
     res.redirect('/login');
   });
+});
+
+router.get('/invite', requireAuth, (req, res) => {
+  res.render('auth/invite', { error: null, invite: null, inviteLink: null, values: {} });
+});
+
+router.post('/invite', requireAuth, (req, res) => {
+  const { email, expires_in_days: expiresInDaysRaw } = req.body;
+  const values = { email: email || '', expires_in_days: expiresInDaysRaw };
+
+  let invite = null;
+  try {
+    let expiresAt = null;
+    if (expiresInDaysRaw) {
+      const expiresInDays = Number(expiresInDaysRaw);
+      if (Number.isNaN(expiresInDays) || expiresInDays <= 0) {
+        throw new Error('Expiration must be a positive number of days.');
+      }
+      expiresAt = new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000).toISOString();
+    }
+    invite = users.invites.create({ email: email || null, invitedBy: req.session.user.id, expiresAt });
+    const inviteLink = `${req.protocol}://${req.get('host')}/register?token=${invite.token}`;
+    res.render('auth/invite', { error: null, invite, inviteLink, values: {} });
+  } catch (err) {
+    res.status(400).render('auth/invite', { error: err.message, invite, inviteLink: null, values });
+  }
+});
+
+function renderRegister(res, options = {}) {
+  const defaults = { error: null, invite: null, token: '', values: {} };
+  res.render('auth/register', { ...defaults, ...options });
+}
+
+router.get('/register', (req, res) => {
+  if (req.session.user) return res.redirect('/');
+  const { token } = req.query;
+  if (!token) {
+    return res.status(400).render('auth/register', {
+      error: 'An invite token is required to register.',
+      invite: null,
+      token: '',
+      values: {}
+    });
+  }
+
+  const invite = users.invites.findByToken(token);
+  if (!invite) {
+    return res.status(404).render('auth/register', {
+      error: 'Invite not found. Please request a new invitation.',
+      invite: null,
+      token,
+      values: {}
+    });
+  }
+
+  if (invite.accepted_at) {
+    return res.status(410).render('auth/register', {
+      error: 'This invite has already been used.',
+      invite,
+      token,
+      values: {}
+    });
+  }
+
+  if (invite.expires_at) {
+    const expiresAt = new Date(invite.expires_at);
+    if (!Number.isNaN(expiresAt.getTime()) && expiresAt < new Date()) {
+      return res.status(410).render('auth/register', {
+        error: 'This invite has expired. Please request a new one.',
+        invite,
+        token,
+        values: {}
+      });
+    }
+  }
+
+  renderRegister(res, { invite, token });
+});
+
+router.post('/register', loginLimiter, (req, res) => {
+  if (req.session.user) return res.redirect('/');
+
+  const { token, username, password, confirm_password: confirmPassword } = req.body;
+  const values = { username: username || '' };
+
+  if (!token) {
+    return res.status(400).render('auth/register', {
+      error: 'Invite token is required.',
+      invite: null,
+      token: '',
+      values
+    });
+  }
+
+  const invite = users.invites.findByToken(token);
+  if (!invite) {
+    return res.status(404).render('auth/register', {
+      error: 'Invite not found. Please request a new invitation.',
+      invite: null,
+      token,
+      values
+    });
+  }
+
+  if (invite.accepted_at) {
+    return res.status(410).render('auth/register', {
+      error: 'This invite has already been used.',
+      invite,
+      token,
+      values
+    });
+  }
+
+  if (invite.expires_at) {
+    const expiresAt = new Date(invite.expires_at);
+    if (!Number.isNaN(expiresAt.getTime()) && expiresAt < new Date()) {
+      return res.status(410).render('auth/register', {
+        error: 'This invite has expired. Please request a new one.',
+        invite,
+        token,
+        values
+      });
+    }
+  }
+
+  if (!username) {
+    return res.status(400).render('auth/register', {
+      error: 'Username is required.',
+      invite,
+      token,
+      values
+    });
+  }
+
+  if (!password) {
+    return res.status(400).render('auth/register', {
+      error: 'Password is required.',
+      invite,
+      token,
+      values
+    });
+  }
+
+  if (password !== confirmPassword) {
+    return res.status(400).render('auth/register', {
+      error: 'Passwords do not match.',
+      invite,
+      token,
+      values
+    });
+  }
+
+  try {
+    const passwordHash = bcrypt.hashSync(password, 12);
+    const { user } = users.invites.accept({ token, username, passwordHash });
+    req.session.user = user;
+    return res.redirect('/');
+  } catch (err) {
+    return res.status(400).render('auth/register', {
+      error: err.message,
+      invite,
+      token,
+      values
+    });
+  }
 });
 
 module.exports = router;

--- a/src/views/auth/invite.ejs
+++ b/src/views/auth/invite.ejs
@@ -1,0 +1,32 @@
+<% const content = (function(){ %>
+  <h2>Invite a User</h2>
+  <p>Generate an invitation link to onboard another administrator.</p>
+  <% if (error) { %>
+    <div class="alert alert-error"><%= error %></div>
+  <% } %>
+  <% if (invite) { %>
+    <div class="alert alert-success">
+      <p><strong>Invitation created!</strong></p>
+      <p>Share this link with the invitee:</p>
+      <code><%= inviteLink %></code>
+      <% if (invite.expires_at) { %>
+        <% const expires = new Date(invite.expires_at); %>
+        <% if (!Number.isNaN(expires.getTime())) { %>
+          <p>This link expires on <%= expires.toLocaleString() %>.</p>
+        <% } %>
+      <% } %>
+    </div>
+  <% } %>
+  <form method="post" action="/invite" class="form">
+    <label>
+      Email (optional)
+      <input type="email" name="email" value="<%= values.email || '' %>" placeholder="friend@example.com">
+    </label>
+    <label>
+      Expiration (days, optional)
+      <input type="number" min="1" name="expires_in_days" value="<%= values.expires_in_days || '' %>" placeholder="7">
+    </label>
+    <button class="btn" type="submit">Create invite</button>
+  </form>
+<% })(); %>
+<%- include('../partials/layout', { body: content }) %>

--- a/src/views/auth/register.ejs
+++ b/src/views/auth/register.ejs
@@ -1,0 +1,29 @@
+<% const content = (function(){ %>
+  <h2>Complete Your Registration</h2>
+  <% if (invite && invite.email) { %>
+    <p>Invited email: <strong><%= invite.email %></strong></p>
+  <% } %>
+  <% if (invite && invite.inviter_username) { %>
+    <p>Invited by: <strong><%= invite.inviter_username %></strong></p>
+  <% } %>
+  <% if (error) { %>
+    <div class="alert alert-error"><%= error %></div>
+  <% } %>
+  <form method="post" action="/register" class="form">
+    <input type="hidden" name="token" value="<%= token %>">
+    <label>
+      Username
+      <input type="text" name="username" value="<%= values.username || '' %>" required>
+    </label>
+    <label>
+      Password
+      <input type="password" name="password" required>
+    </label>
+    <label>
+      Confirm password
+      <input type="password" name="confirm_password" required>
+    </label>
+    <button class="btn" type="submit">Create account</button>
+  </form>
+<% })(); %>
+<%- include('../partials/layout', { body: content }) %>


### PR DESCRIPTION
## Summary
- add persistent user and invite tables with automatic admin seeding
- introduce database helpers and auth routes for login, invitation, and registration flows
- refresh session handling and templates to support invitation-based onboarding

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69091260921483329b2e5daca4f3536c