### PR TITLE
Update layout header with login link

### DIFF
--- a/src/views/partials/layout.ejs
+++ b/src/views/partials/layout.ejs
@@ -3,17 +3,19 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>PPCollection</title>
+  <title>Pew Pew Collection</title>
   <link rel="stylesheet" href="/static/css/styles.css">
 </head>
 <body>
   <header class="topbar">
     <div class="container">
-      <h1><a href="/">PPCollection</a></h1>
+      <h1><a href="/">Pew Pew Collection</a></h1>
       <% if (user) { %>
       <form method="post" action="/logout">
         <button class="btn btn-secondary" type="submit">Logout (<%= user.username %>)</button>
       </form>
+      <% } else { %>
+      <a class="btn btn-secondary" href="/login">Login</a>
       <% } %>
     </div>
   </header>


### PR DESCRIPTION
## Summary
- rename the layout title and header link to "Pew Pew Collection"
- show a login link when no user is present while keeping the logout button for authenticated users

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6909203b209c8332af679ec8f26292bd