### PR TITLE
Add Flatpickr-based date picker to library form

### DIFF
--- a/src/views/library/_form.ejs
+++ b/src/views/library/_form.ejs
@@ -20,7 +20,7 @@
 </div>
 <div>
   <label>Purchase Date
-    <input type="date" name="purchase_date" value="<%= item.purchase_date || '' %>">
+    <input type="text" class="js-date-picker" name="purchase_date" value="<%= item.purchase_date || '' %>">
   </label>
 </div>
 <div>

--- a/src/views/partials/layout.ejs
+++ b/src/views/partials/layout.ejs
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Pew Pew Collection</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
   <link rel="stylesheet" href="/static/css/styles.css">
 </head>
 <body>
@@ -25,6 +26,16 @@
   <footer class="footer container">
     <small>Local-only collection. Data stored in SQLite.</small>
   </footer>
+  <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      if (window.flatpickr) {
+        window.flatpickr('.js-date-picker', {
+          dateFormat: 'Y-m-d',
+        });
+      }
+    });
+  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- load Flatpickr assets from a CDN in the shared layout and initialize the widget for date inputs
- tag the library form purchase date input for Flatpickr usage so dates remain ISO formatted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69093812fde88332a5707bf58c66abe6