### PR TITLE
Fix default admin login password

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const bcrypt = require('bcryptjs');
 
 // Pre-computed hash for default password 'changeme'
 // Generated with: bcrypt.hashSync('changeme', 10)
-const DEFAULT_PASSWORD_HASH = '$2b$10$z90/lwCXasYplpSFkYcAfeuhMW5lDGYAk4I3ouhJ3z2hl5/u5O2Eu';
+const DEFAULT_PASSWORD_HASH = '$2b$10$n9ltB2FRl72JqqoGJvrCDuLwVqFl7hWffe1jsmso.Ss80TwnTdUPK';
 
 // Support migration from plain-text password to hashed password
 let adminPasswordHash;


### PR DESCRIPTION
## Summary
- replace the incorrect built-in bcrypt hash so the default `admin` user is created with the documented `changeme` password

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a6334a6f083329484ad50aa0c9c34)