### PR TITLE
Make session cookie security configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,12 @@ docker run -d \
 > ⚠️ **Security Warning**: Plain-text passwords via `ADMIN_PASSWORD` are deprecated and will show a warning. Use `ADMIN_PASSWORD_HASH` instead.
 
 ```bash
-docker run -d \
+ docker run -d \
   -p 3000:3000 \
   -e ADMIN_USERNAME=admin \
   -e ADMIN_PASSWORD=changeme \
   -e SESSION_SECRET=your-secret-here \
+  -e SESSION_COOKIE_SECURE=false \
   -v ./data:/data \
   ghcr.io/gogorichielab/ppcollection:latest
 ```
@@ -107,11 +108,16 @@ npm start
 npm install
 export PORT=3000
 export SESSION_SECRET=devsecret
+export SESSION_COOKIE_SECURE=false # Set to true when serving over HTTPS
 export ADMIN_USERNAME=admin
 export ADMIN_PASSWORD=changeme
 export DATABASE_PATH="$PWD/data/app.db"
 npm start
 ```
+
+**Cookie security**
+
+Set `SESSION_COOKIE_SECURE=true` when running behind HTTPS or a reverse proxy that terminates TLS. Leave it `false` (the default) for plain HTTP setups so the login session cookie can be set correctly.
 
 Then open <http://localhost:3000> in your browser.
 

--- a/src/config.js
+++ b/src/config.js
@@ -25,6 +25,8 @@ module.exports = {
   sessionSecret: process.env.SESSION_SECRET || 'ppcollection_dev_secret',
   adminUser: process.env.ADMIN_USERNAME || 'admin',
   adminPasswordHash: adminPasswordHash,
+  // Explicit toggle for secure cookies so deployments behind HTTP can still log in.
+  sessionCookieSecure: process.env.SESSION_COOKIE_SECURE === 'true',
   databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db')
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -5,7 +5,7 @@ const methodOverride = require('method-override');
 const helmet = require('helmet');
 const morgan = require('morgan');
 const lusca = require('lusca');
-const { port, sessionSecret } = require('./config');
+const { port, sessionSecret, sessionCookieSecure } = require('./config');
 const { requireAuth, checkPasswordChangeRequired } = require('./middleware/auth');
 const users = require('./db/users');
 
@@ -27,7 +27,7 @@ app.use(
     saveUninitialized: false,
     cookie: {
       maxAge: 1000 * 60 * 60 * 8,
-      secure: process.env.NODE_ENV === 'production',
+      secure: sessionCookieSecure,
       httpOnly: true
     }
   })


### PR DESCRIPTION
## Summary
- add a configurable SESSION_COOKIE_SECURE flag so deployments can run over HTTP without blocking logins
- update session configuration to honor the flag instead of always requiring secure cookies
- document the new environment variable and when to enable it

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692430250a008332b8021295cfd42383)