### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Auto-Delete-merged-branch.yml
+++ b/.github/workflows/Auto-Delete-merged-branch.yml
@@ -1,4 +1,6 @@
 name: Auto delete branch on close pr
+permissions:
+  contents: write
 on: 
   pull_request:
     types: [closed]


### PR DESCRIPTION
Potential fix for [https://github.com/Gogorichielab/PPCollection/security/code-scanning/1](https://github.com/Gogorichielab/PPCollection/security/code-scanning/1)

To fix the issue, you should add a `permissions` block specifying the minimal required permissions for `GITHUB_TOKEN`. Since this workflow is used to auto-delete merged branches, it needs permission to modify contents (i.e., delete refs/branches), so `contents: write` is required. This permission can be set at the job or workflow level. For clarity and least privilege, add the following to the root of the workflow file (top-level):  
```yaml
permissions:
  contents: write
```  
This ensures that only the necessary permission(s) are granted, and avoids accidental permission escalation.

**Files/regions to change:**  
- File: `.github/workflows/Auto-Delete-merged-branch.yml`
- Region: Directly after the `name:` line (top-level)

No additional imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
