### PR TITLE
Enhance firearm detail layout

### DIFF
--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -287,11 +287,60 @@ a {
   justify-content: flex-end;
 }
 
+.item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.item-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--border);
+}
+
+.badge-accent {
+  background: linear-gradient(120deg, rgba(31, 75, 95, 0.36), rgba(31, 75, 95, 0.16));
+  border-color: rgba(31, 75, 95, 0.45);
+}
+
+.badge-outline {
+  background: transparent;
+  color: var(--muted);
+}
+
 .flex-between {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 16px;
+}
+
+.item-toolbar {
+  display: flex;
+  gap: 10px;
+  margin: 14px 0;
+  flex-wrap: wrap;
 }
 
 .table-wrapper {
@@ -375,6 +424,43 @@ a {
   border-radius: 10px;
   border: 1px solid var(--border);
   transition: background-color 0.3s ease;
+}
+
+@media (max-width: 640px) {
+  .details {
+    grid-template-columns: 1fr;
+  }
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 14px;
+}
+
+.detail-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: var(--shadow-soft);
+  padding: 14px 14px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.detail-card .details {
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+
+.section-header {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.12rem;
+  color: var(--muted);
+  font-weight: 700;
 }
 
 .notes {

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -1,5 +1,11 @@
-  <div class="flex-between">
-    <h2><%= item.make %> <%= item.model %></h2>
+  <div class="item-header">
+    <div class="item-title-block">
+      <h2><%= item.make %> <%= item.model %></h2>
+      <div class="badge-row">
+        <span class="badge badge-accent"><%= item.status || 'Unknown Status' %></span>
+        <span class="badge badge-outline"><%= item.firearm_type || 'Unknown Type' %></span>
+      </div>
+    </div>
     <div class="actions">
       <a class="btn" href="/firearms/<%= item.id %>/edit">Edit</a>
       <form method="post" action="/firearms/<%= item.id %>/delete" onsubmit="return confirm('Delete this firearm?');" style="display:inline">
@@ -8,17 +14,37 @@
     </div>
   </div>
 
-  <dl class="details">
-    <dt>Serial</dt><dd><%= item.serial || '-' %></dd>
-    <dt>Caliber</dt><dd><%= item.caliber || '-' %></dd>
-    <dt>Firearm Type</dt><dd><%= item.firearm_type || '-' %></dd>
-    <dt>Purchase Date</dt><dd><%= item.purchase_date || '-' %></dd>
-    <dt>Purchase Price</dt><dd><%= (item.purchase_price !== null && item.purchase_price !== undefined) ? ('$' + item.purchase_price) : '-' %></dd>
-    <dt>Purchase Condition</dt><dd><%= item.condition || '-' %></dd>
-    <dt>Location</dt><dd><%= item.location || '-' %></dd>
-    <dt>Status</dt><dd><%= item.status || '-' %></dd>
-    <dt>Gun Warranty</dt><dd><%= item.gun_warranty === 1 ? 'Yes' : (item.gun_warranty === 0 ? 'No' : '-') %></dd>
-    <dt>Notes</dt><dd><pre class="notes"><%= item.notes || '-' %></pre></dd>
-  </dl>
+  <div class="item-toolbar">
+    <a class="btn btn-secondary" href="/firearms">← Back to list</a>
+    <a class="btn btn-secondary" href="/firearms/<%= item.id %>/duplicate">Duplicate</a>
+    <button class="btn btn-secondary" type="button" onclick="window.print()">Print / Export</button>
+  </div>
 
-  <p><a href="/firearms">Back to list</a></p>
+  <div class="detail-grid">
+    <section class="detail-card">
+      <header class="section-header">Profile</header>
+      <dl class="details">
+        <dt>Serial</dt><dd><%= item.serial || '-' %></dd>
+        <dt>Caliber</dt><dd><%= item.caliber || '-' %></dd>
+        <dt>Location</dt><dd><%= item.location || '-' %></dd>
+        <dt>Notes</dt><dd><pre class="notes"><%= item.notes || '-' %></pre></dd>
+      </dl>
+    </section>
+
+    <section class="detail-card">
+      <header class="section-header">Ownership</header>
+      <dl class="details">
+        <dt>Status</dt><dd><%= item.status || '-' %></dd>
+        <dt>Gun Warranty</dt><dd><%= item.gun_warranty === 1 ? 'Yes' : (item.gun_warranty === 0 ? 'No' : '-') %></dd>
+      </dl>
+    </section>
+
+    <section class="detail-card">
+      <header class="section-header">Purchase</header>
+      <dl class="details">
+        <dt>Purchase Date</dt><dd><%= item.purchase_date || '-' %></dd>
+        <dt>Purchase Price</dt><dd><%= (item.purchase_price !== null && item.purchase_price !== undefined) ? ('$' + item.purchase_price) : '-' %></dd>
+        <dt>Purchase Condition</dt><dd><%= item.condition || '-' %></dd>
+      </dl>
+    </section>
+  </div>


### PR DESCRIPTION
## Summary
- add status and type badges alongside firearm titles and introduce a multi-action toolbar
- reorganize firearm details into ownership and purchase cards within a responsive two-column layout
- update styling for new badges, toolbar controls, and card-based presentation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692776f27a308332a0e8400488294ac3)