### PR TITLE
feat(version): add cached GitHub release update indicator to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The application is configured through environment variables:
 | `ADMIN_USERNAME` | Admin username for login | `admin` | Single admin user for authentication |
 | `ADMIN_PASSWORD` | Initial admin password | `changeme` | Used to seed password hash on first startup - you'll be forced to change it on first login |
 | `DATABASE_PATH` | Location of SQLite database | `<project>/data/app.db` | In Docker: `/data/app.db` |
+| `UPDATE_CHECK` | Enable automatic update checks against GitHub releases | `false` | Requires outbound HTTPS to `api.github.com`; leave unset for fully offline installs |
 
 ### Security Notes
 

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -6,7 +6,8 @@ function getConfig() {
     sessionSecret: process.env.SESSION_SECRET || 'ppcollection_dev_secret',
     adminUser: process.env.ADMIN_USERNAME || 'admin',
     adminPass: process.env.ADMIN_PASSWORD || 'changeme',
-    databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db')
+    databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db'),
+    updateCheck: process.env.UPDATE_CHECK === 'true'
   };
 }
 

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -737,6 +737,43 @@ a {
   background: rgba(179, 116, 43, 0.1);
 }
 
+.app-footer {
+  margin-top: 40px;
+  border-top: 1px solid var(--border);
+  padding: 16px 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.footer-version {
+  opacity: 0.6;
+}
+
+.footer-update-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, rgba(194, 137, 79, 0.18), rgba(194, 137, 79, 0.08));
+  border: 1px solid rgba(194, 137, 79, 0.4);
+  color: var(--accent2);
+  font-weight: 600;
+  text-decoration: none;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.footer-update-badge:hover {
+  background: linear-gradient(120deg, rgba(194, 137, 79, 0.28), rgba(194, 137, 79, 0.14));
+  box-shadow: var(--shadow-soft);
+}
+
 @media (max-width: 640px) {
   .topbar .container {
     flex-direction: column;
@@ -762,5 +799,10 @@ a {
   .header-controls {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .footer-inner {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/src/services/version.service.js
+++ b/src/services/version.service.js
@@ -1,0 +1,100 @@
+const https = require('https');
+
+const RELEASES_URL = 'https://api.github.com/repos/Gogorichielab/PPCollection/releases/latest';
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+function compareVersions(left, right) {
+  const leftParts = String(left)
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0);
+  const rightParts = String(right)
+    .split('.')
+    .map((part) => Number.parseInt(part, 10) || 0);
+  const maxLength = Math.max(leftParts.length, rightParts.length);
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftPart = leftParts[index] || 0;
+    const rightPart = rightParts[index] || 0;
+
+    if (leftPart > rightPart) {
+      return 1;
+    }
+
+    if (leftPart < rightPart) {
+      return -1;
+    }
+  }
+
+  return 0;
+}
+
+function createVersionService({ currentVersion, enabled, now = () => Date.now() }) {
+  let cachedLatestVersion = null;
+  let lastCheckedAt = null;
+
+  function fetchLatestVersion() {
+    return new Promise((resolve) => {
+      const request = https.get(
+        RELEASES_URL,
+        {
+          headers: {
+            'User-Agent': `PPCollection/${currentVersion}`,
+            Accept: 'application/vnd.github+json'
+          }
+        },
+        (response) => {
+          let data = '';
+
+          response.on('data', (chunk) => {
+            data += chunk;
+          });
+
+          response.on('end', () => {
+            try {
+              const json = JSON.parse(data);
+              const normalized = typeof json.tag_name === 'string' ? json.tag_name.replace(/^v/i, '') : null;
+              resolve(normalized || null);
+            } catch {
+              resolve(null);
+            }
+          });
+        }
+      );
+
+      request.on('error', () => resolve(null));
+      request.setTimeout?.(5000, () => {
+        request.destroy();
+        resolve(null);
+      });
+    });
+  }
+
+  async function getVersionInfo() {
+    if (!enabled) {
+      return { currentVersion, latestVersion: null, updateAvailable: false };
+    }
+
+    const timestamp = now();
+    if (lastCheckedAt === null || timestamp - lastCheckedAt > CACHE_TTL_MS) {
+      cachedLatestVersion = await fetchLatestVersion();
+      lastCheckedAt = timestamp;
+    }
+
+    const updateAvailable =
+      typeof cachedLatestVersion === 'string' && compareVersions(cachedLatestVersion, currentVersion) > 0;
+
+    return {
+      currentVersion,
+      latestVersion: cachedLatestVersion,
+      updateAvailable
+    };
+  }
+
+  return { getVersionInfo };
+}
+
+module.exports = {
+  CACHE_TTL_MS,
+  RELEASES_URL,
+  createVersionService
+};

--- a/src/views/partials/layout.ejs
+++ b/src/views/partials/layout.ejs
@@ -47,6 +47,21 @@
   <main class="container">
     <%- body %>
   </main>
+  <footer class="app-footer">
+    <div class="container footer-inner">
+      <span class="footer-version">PPCollection v<%= versionInfo.currentVersion %></span>
+      <% if (versionInfo.updateAvailable) { %>
+      <a
+        class="footer-update-badge"
+        href="https://github.com/Gogorichielab/PPCollection/releases/latest"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        v<%= versionInfo.latestVersion %> available — view release
+      </a>
+      <% } %>
+    </div>
+  </footer>
   <script src="/static/js/theme.js"></script>
 </body>
 </html>

--- a/tests/unit/version.service.test.js
+++ b/tests/unit/version.service.test.js
@@ -1,0 +1,87 @@
+const EventEmitter = require('events');
+const https = require('https');
+
+const { CACHE_TTL_MS, createVersionService } = require('../../src/services/version.service');
+
+function mockGithubResponse({ payload, error }) {
+  jest.spyOn(https, 'get').mockImplementation((_url, _options, callback) => {
+    const request = new EventEmitter();
+    request.destroy = jest.fn();
+    request.setTimeout = jest.fn();
+
+    process.nextTick(() => {
+      if (error) {
+        request.emit('error', error);
+        return;
+      }
+
+      const response = new EventEmitter();
+      callback(response);
+      response.emit('data', JSON.stringify(payload));
+      response.emit('end');
+    });
+
+    return request;
+  });
+}
+
+describe('version service', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('returns updateAvailable=true when newer version exists and caches for 24 hours', async () => {
+    mockGithubResponse({ payload: { tag_name: 'v1.10.0' } });
+
+    let nowMs = 1000;
+    const service = createVersionService({
+      currentVersion: '1.9.1',
+      enabled: true,
+      now: () => nowMs
+    });
+
+    const firstResult = await service.getVersionInfo();
+    const secondResult = await service.getVersionInfo();
+
+    expect(firstResult).toEqual({ currentVersion: '1.9.1', latestVersion: '1.10.0', updateAvailable: true });
+    expect(secondResult).toEqual(firstResult);
+    expect(https.get).toHaveBeenCalledTimes(1);
+
+    nowMs += CACHE_TTL_MS + 1;
+    await service.getVersionInfo();
+
+    expect(https.get).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns updateAvailable=false when current version is up to date', async () => {
+    mockGithubResponse({ payload: { tag_name: 'v1.9.1' } });
+
+    const service = createVersionService({ currentVersion: '1.9.1', enabled: true });
+    const result = await service.getVersionInfo();
+
+    expect(result).toEqual({ currentVersion: '1.9.1', latestVersion: '1.9.1', updateAvailable: false });
+    expect(https.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('returns no update info and does not call network when disabled', async () => {
+    const getSpy = jest.spyOn(https, 'get');
+    const service = createVersionService({ currentVersion: '1.9.1', enabled: false });
+
+    const result = await service.getVersionInfo();
+
+    expect(result).toEqual({ currentVersion: '1.9.1', latestVersion: null, updateAvailable: false });
+    expect(getSpy).not.toHaveBeenCalled();
+  });
+
+  test('fails silently on network errors', async () => {
+    mockGithubResponse({ error: new Error('network down') });
+    const service = createVersionService({ currentVersion: '1.9.1', enabled: true });
+
+    await expect(service.getVersionInfo()).resolves.toEqual({
+      currentVersion: '1.9.1',
+      latestVersion: null,
+      updateAvailable: false
+    });
+    expect(https.get).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a subtle, opt-in indicator in the app footer when a newer PPCollection release exists on GitHub while keeping the app offline-first and failing silently on network issues.
- Avoid per-request network traffic by calling the GitHub API once on startup and caching the result for 24 hours.

### Description

- Add `updateCheck` config flag sourced from `UPDATE_CHECK` to `src/infra/config/index.js` to make update checks opt-in.
- Implement `src/services/version.service.js` which fetches and normalizes the latest GitHub release tag, compares semantic versions, caches the result for 24 hours, and returns safe defaults on errors/timeouts.
- Wire the version service into `src/app/createApp.js`, exposing `versionInfo` on `res.locals` so views always have the current version and optional update availability.
- Render a footer in `src/views/partials/layout.ejs` that always shows the running version and conditionally shows a link to the latest release, and add corresponding styles to `src/public/css/styles.css` with mobile adjustments inside the existing `@media (max-width: 640px)` block.
- Add `tests/unit/version.service.test.js` covering: update available, up-to-date, disabled (no network call), and network failure cases, and document `UPDATE_CHECK` in `README.md`.

### Testing

- Ran the new unit tests with `npx jest tests/unit/version.service.test.js --runInBand`, and they passed (all version service scenarios succeeded).
- Ran `npm test` in the environment, which executed unit suites but the overall run failed because integration suites could not start due to a missing `csurf` module in the test environment, preventing full integration validation.
- Attempted `npm start` locally but startup failed for the same missing `csurf` dependency; unit test coverage for the new service was reported during the run and is included in the test output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699535605da883328425e4d09b3c4cd9)