### PR TITLE
fix(firearms): server-side validation and inline errors for make/model

### DIFF
--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -1,4 +1,4 @@
-const { sanitizeFirearmInput } = require('./firearms.validators');
+const { sanitizeFirearmInput, validateFirearmInput } = require('./firearms.validators');
 
 function createFirearmsController(firearmsService) {
   return {
@@ -17,13 +17,23 @@ function createFirearmsController(firearmsService) {
     },
 
     showNew(req, res) {
-      res.render('firearms/new', { item: {} });
+      res.render('firearms/new', { item: {}, fieldErrors: {}, error: null });
     },
 
     create(req, res) {
       const data = sanitizeFirearmInput(req.body);
+      const { isValid, fieldErrors } = validateFirearmInput(data);
+
+      if (!isValid) {
+        return res.status(400).render('firearms/new', {
+          item: data,
+          fieldErrors,
+          error: 'Please correct the highlighted fields and try again.'
+        });
+      }
+
       const id = firearmsService.create(data);
-      res.redirect(`/firearms/${id}`);
+      return res.redirect(`/firearms/${id}`);
     },
 
     show(req, res) {

--- a/src/features/firearms/firearms.validators.js
+++ b/src/features/firearms/firearms.validators.js
@@ -15,4 +15,21 @@ function sanitizeFirearmInput(body) {
   };
 }
 
-module.exports = { sanitizeFirearmInput };
+function validateFirearmInput(data) {
+  const fieldErrors = {};
+
+  if (!data.make) {
+    fieldErrors.make = 'Make is required.';
+  }
+
+  if (!data.model) {
+    fieldErrors.model = 'Model is required.';
+  }
+
+  return {
+    isValid: Object.keys(fieldErrors).length === 0,
+    fieldErrors
+  };
+}
+
+module.exports = { sanitizeFirearmInput, validateFirearmInput };

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -261,6 +261,22 @@ a {
   line-height: 1.4;
 }
 
+.field-error {
+  display: block;
+  margin-top: 4px;
+  font-size: 13px;
+  color: #ffdede;
+  font-weight: 600;
+}
+
+[data-theme="light"] .field-error {
+  color: #8c2f2f;
+}
+
+.form input[aria-invalid="true"] {
+  border-color: rgba(140, 47, 47, 0.8);
+}
+
 .form input,
 .form textarea,
 .search-input,

--- a/src/views/firearms/_form.ejs
+++ b/src/views/firearms/_form.ejs
@@ -1,11 +1,17 @@
 <div>
   <label>Make <span class="required-marker">*</span>
-    <input name="make" required aria-required="true" value="<%= item.make || '' %>">
+    <input name="make" required aria-required="true" aria-invalid="<%= fieldErrors && fieldErrors.make ? 'true' : 'false' %>" value="<%= item.make || '' %>">
+    <% if (fieldErrors && fieldErrors.make) { %>
+      <small class="field-error"><%= fieldErrors.make %></small>
+    <% } %>
   </label>
 </div>
 <div>
   <label>Model <span class="required-marker">*</span>
-    <input name="model" required aria-required="true" value="<%= item.model || '' %>">
+    <input name="model" required aria-required="true" aria-invalid="<%= fieldErrors && fieldErrors.model ? 'true' : 'false' %>" value="<%= item.model || '' %>">
+    <% if (fieldErrors && fieldErrors.model) { %>
+      <small class="field-error"><%= fieldErrors.model %></small>
+    <% } %>
   </label>
 </div>
 <div>

--- a/src/views/firearms/edit-content.ejs
+++ b/src/views/firearms/edit-content.ejs
@@ -1,7 +1,7 @@
   <h2>Edit Firearm</h2>
   <form method="post" action="/firearms/<%= item.id %>?_method=PUT" class="form grid">
     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-    <%- include('./_form', { item }) %>
+    <%- include('./_form', { item, fieldErrors: {} }) %>
     <div class="form-actions">
       <a class="btn btn-secondary" href="/firearms/<%= item.id %>">Cancel</a>
       <button class="btn" type="submit">Save</button>

--- a/src/views/firearms/new-content.ejs
+++ b/src/views/firearms/new-content.ejs
@@ -1,7 +1,10 @@
   <h2>New Firearm</h2>
+  <% if (error) { %>
+    <div class="alert alert-error"><%= error %></div>
+  <% } %>
   <form method="post" action="/firearms" class="form grid">
     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
-    <%- include('./_form', { item }) %>
+    <%- include('./_form', { item, fieldErrors: fieldErrors || {} }) %>
     <div class="form-actions">
       <a class="btn btn-secondary" href="/firearms">Cancel</a>
       <button class="btn" type="submit">Create</button>

--- a/tests/integration/firearms.integration.test.js
+++ b/tests/integration/firearms.integration.test.js
@@ -136,6 +136,31 @@ describe('firearms routes', () => {
     expect(listResponse.text).toContain('No firearms yet');
   });
 
+
+  test('create rejects missing make and model with inline errors', async () => {
+    const newPage = await agent.get('/firearms/new');
+    const createCsrfToken = extractCsrfToken(newPage.text);
+
+    const createResponse = await agent
+      .post('/firearms')
+      .type('form')
+      .send({
+        make: '   ',
+        model: '',
+        serial: 'ABC123',
+        _csrf: createCsrfToken
+      });
+
+    expect(createResponse.status).toBe(400);
+    expect(createResponse.text).toContain('Please correct the highlighted fields and try again.');
+    expect(createResponse.text).toContain('Make is required.');
+    expect(createResponse.text).toContain('Model is required.');
+
+    const listResponse = await agent.get('/firearms');
+    expect(listResponse.status).toBe(200);
+    expect(listResponse.text).toContain('No firearms yet');
+  });
+
   test('CSV export returns download headers and content', async () => {
     const newPage = await agent.get('/firearms/new');
     const createCsrfToken = extractCsrfToken(newPage.text);

--- a/tests/unit/firearms.validators.test.js
+++ b/tests/unit/firearms.validators.test.js
@@ -1,0 +1,27 @@
+const { sanitizeFirearmInput, validateFirearmInput } = require('../../src/features/firearms/firearms.validators');
+
+describe('firearms.validators', () => {
+  test('sanitizeFirearmInput trims strings and normalizes values', () => {
+    const data = sanitizeFirearmInput({
+      make: '  Glock ',
+      model: ' 19 ',
+      purchase_price: '500.25',
+      gun_warranty: 'on'
+    });
+
+    expect(data.make).toBe('Glock');
+    expect(data.model).toBe('19');
+    expect(data.purchase_price).toBe(500.25);
+    expect(data.gun_warranty).toBe(1);
+  });
+
+  test('validateFirearmInput requires make and model', () => {
+    const result = validateFirearmInput({ make: '', model: '' });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors).toEqual({
+      make: 'Make is required.',
+      model: 'Model is required.'
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent database errors and give users clear feedback by validating required `make` and `model` fields on the firearm create form.

### Description
- Added `validateFirearmInput` and exported it from `src/features/firearms/firearms.validators.js` to enforce required `make`/`model` rules and return field-level errors.
- Wired validation into the create flow in `src/features/firearms/firearms.controller.js` to return HTTP 400 and re-render the `new` form with `fieldErrors` and a friendly alert when validation fails.
- Updated the new form and shared partial (`src/views/firearms/new-content.ejs`, `src/views/firearms/_form.ejs`, `src/views/firearms/edit-content.ejs`) to render inline error messages, set `aria-invalid`, and keep edit flow compatible by passing an empty `fieldErrors` object for edits.
- Added UI styles for field errors and invalid inputs in `src/public/css/styles.css` and preserved visual behavior across light/dark themes.
- Added tests: a unit test for validators at `tests/unit/firearms.validators.test.js` and an integration test covering invalid create submissions in `tests/integration/firearms.integration.test.js`.

### Testing
- Ran the full test suite with `npm test`; all test suites passed (5 passed, 21 tests total). 
- The new unit test `tests/unit/firearms.validators.test.js` passed and the integration test covering the invalid-create path passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953fea72d883329cb0b50249370629)