### PR TITLE
fix(home): refine hero layout and repair dashboard styles

### DIFF
--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -18,6 +18,9 @@ const { createAuthRoutes } = require('../features/auth/auth.routes');
 const { createFirearmsService } = require('../features/firearms/firearms.service');
 const { createFirearmsController } = require('../features/firearms/firearms.controller');
 const { createFirearmsRoutes } = require('../features/firearms/firearms.routes');
+const { createHomeService } = require('../features/home/home.service');
+const { createHomeController } = require('../features/home/home.controller');
+const { createHomeRoutes } = require('../features/home/home.routes');
 
 async function createApp(options = {}) {
   const config = options.config || getConfig();
@@ -36,6 +39,8 @@ async function createApp(options = {}) {
   const authController = createAuthController(authService);
   const firearmsService = createFirearmsService(firearmsRepository);
   const firearmsController = createFirearmsController(firearmsService);
+  const homeService = createHomeService(firearmsRepository);
+  const homeController = createHomeController(homeService);
 
   const app = express();
 
@@ -71,6 +76,7 @@ async function createApp(options = {}) {
 
   registerRoutes(app, {
     authRoutes: createAuthRoutes(authController),
+    homeRoutes: createHomeRoutes(homeController),
     firearmsRoutes: createFirearmsRoutes(firearmsController)
   });
 

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -1,9 +1,8 @@
 const { requireAuth } = require('../middleware/auth');
 
-function registerRoutes(app, { authRoutes, firearmsRoutes }) {
+function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes }) {
   app.use('/', authRoutes);
-
-  app.get('/', requireAuth, (req, res) => res.redirect('/firearms'));
+  app.use('/', requireAuth, homeRoutes);
   app.use('/firearms', requireAuth, firearmsRoutes);
 }
 

--- a/src/features/home/home.controller.js
+++ b/src/features/home/home.controller.js
@@ -1,0 +1,12 @@
+function createHomeController(homeService) {
+  return {
+    index(req, res) {
+      const username = req.session.user?.username || 'Collector';
+      const dashboard = homeService.getDashboard(username);
+
+      return res.render('home/index', dashboard);
+    }
+  };
+}
+
+module.exports = { createHomeController };

--- a/src/features/home/home.routes.js
+++ b/src/features/home/home.routes.js
@@ -1,0 +1,13 @@
+const { Router } = require('express');
+
+function createHomeRoutes(homeController) {
+  const router = Router();
+
+  router.get('/', homeController.index);
+  router.get('/home', homeController.index);
+  router.get('/report', (req, res) => res.redirect('https://github.com/Gogorichielab/PPCollection/issues'));
+
+  return router;
+}
+
+module.exports = { createHomeRoutes };

--- a/src/features/home/home.service.js
+++ b/src/features/home/home.service.js
@@ -1,0 +1,62 @@
+function createHomeService(firearmsRepository) {
+  function toRelativeTime(dateString) {
+    if (!dateString) {
+      return '—';
+    }
+
+    const timestamp = new Date(`${dateString}Z`).getTime();
+    if (Number.isNaN(timestamp)) {
+      return '—';
+    }
+
+    const diffMs = Date.now() - timestamp;
+    const hours = Math.max(0, Math.floor(diffMs / (1000 * 60 * 60)));
+
+    if (hours < 24) {
+      return `${Math.max(1, hours)}h ago`;
+    }
+
+    const days = Math.floor(hours / 24);
+    if (days < 7) {
+      return `${days}d ago`;
+    }
+
+    const weeks = Math.floor(days / 7);
+    return `${weeks}w ago`;
+  }
+
+  return {
+    getDashboard(username) {
+      const summary = firearmsRepository.getCollectionSummary();
+      const recentRecords = firearmsRepository.getRecentActivity(5);
+      const now = Date.now();
+
+      const recentActivity = recentRecords.map((item) => {
+        const createdAt = new Date(`${item.created_at}Z`).getTime();
+        const updatedAt = new Date(`${item.updated_at}Z`).getTime();
+        const eventAt = Number.isNaN(updatedAt) ? createdAt : updatedAt;
+        const isAdded = Math.abs(updatedAt - createdAt) <= 5000;
+
+        return {
+          id: item.id,
+          description: `${isAdded ? 'Added' : 'Updated'} ${item.make} ${item.model}`.trim(),
+          timeAgo: toRelativeTime(item.updated_at || item.created_at),
+          isRecent: now - eventAt < 1000 * 60 * 60 * 24
+        };
+      });
+
+      return {
+        username,
+        stats: {
+          totalFirearms: summary.total_firearms || 0,
+          thisMonth: summary.this_month || 0,
+          categories: summary.categories || 0,
+          lastUpdateDays: summary.last_update_days == null ? '—' : `${summary.last_update_days}d`
+        },
+        recentActivity
+      };
+    }
+  };
+}
+
+module.exports = { createHomeService };

--- a/src/infra/db/repositories/firearms.repository.js
+++ b/src/infra/db/repositories/firearms.repository.js
@@ -70,6 +70,24 @@ function createFirearmsRepository(db) {
     },
     remove(id) {
       db.prepare('DELETE FROM firearms WHERE id = ?').run(id);
+    },
+    getCollectionSummary() {
+      return db.prepare(`
+        SELECT
+          COUNT(*) AS total_firearms,
+          SUM(CASE WHEN strftime('%Y-%m', created_at) = strftime('%Y-%m', 'now') THEN 1 ELSE 0 END) AS this_month,
+          COUNT(DISTINCT firearm_type) AS categories,
+          CAST((julianday('now') - julianday(MAX(updated_at))) AS INTEGER) AS last_update_days
+        FROM firearms
+      `).get();
+    },
+    getRecentActivity(limit = 5) {
+      return db.prepare(`
+        SELECT id, make, model, created_at, updated_at
+        FROM firearms
+        ORDER BY datetime(updated_at) DESC
+        LIMIT ?
+      `).all(limit);
     }
   };
 }

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -878,6 +878,7 @@ a {
   background: rgba(179, 116, 43, 0.1);
 }
 
+
 .pagination {
   display: flex;
   align-items: center;
@@ -889,6 +890,31 @@ a {
 }
 
 .pagination-info {
+  color: var(--muted);
+}
+
+.pagination-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.pagination-current {
+  font-weight: 500;
+  color: var(--text);
+  padding: 0 8px;
+}
+
+.pagination-btn {
+  min-width: 100px;
+}
+
+.pagination-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
 /* Modal Styles */
 .modal-overlay {
   display: none;
@@ -950,26 +976,6 @@ a {
   font-size: 14px;
 }
 
-.pagination-controls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.pagination-current {
-  font-weight: 500;
-  color: var(--text);
-  padding: 0 8px;
-}
-
-.pagination-btn {
-  min-width: 100px;
-}
-
-.pagination-btn:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  pointer-events: none;
 .modal-footer {
   padding: 16px 24px;
   border-top: 1px solid var(--border);
@@ -978,10 +984,201 @@ a {
   justify-content: flex-end;
 }
 
+.page-home main.container {
+  max-width: none;
+  padding: 0;
+}
+
+.home-hero {
+  position: relative;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid var(--border);
+  padding: 32px 36px 28px;
+  margin-bottom: 0;
+}
+
+.home-hero::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 40%;
+  height: 100%;
+  background: radial-gradient(ellipse at right center, rgba(245, 166, 35, 0.06) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.home-hero-tag,
+.home-stat-label,
+.home-card-header h3,
+.activity-time {
+  font-family: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+.home-hero-tag {
+  margin: 0;
+  color: var(--accent2);
+  text-transform: uppercase;
+  letter-spacing: 0.18rem;
+  font-size: 12px;
+}
+
+.home-hero-title {
+  margin: 8px 0 0;
+  font-family: 'Bebas Neue', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+  font-size: 42px;
+  line-height: 0.95;
+  letter-spacing: 0.03rem;
+  text-transform: uppercase;
+}
+
+.home-hero-subtitle {
+  margin: 8px 0 0;
+  color: var(--muted);
+  max-width: 380px;
+}
+
+.home-stats {
+  margin-top: 22px;
+  display: flex;
+}
+
+.home-stat {
+  padding: 0 20px;
+  border-right: 1px solid var(--border);
+}
+
+.home-stat:first-child {
+  padding-left: 0;
+}
+
+.home-stat:last-child {
+  border-right: none;
+}
+
+.home-stat-value {
+  display: block;
+  font-family: 'Bebas Neue', Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
+  font-size: 28px;
+  line-height: 1;
+}
+
+.home-stat-value-accent {
+  color: var(--accent2);
+}
+
+.home-stat-label {
+  display: block;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12rem;
+  color: var(--muted);
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: 16px;
+  padding: 24px 28px;
+}
+
+.home-card {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.home-card-header {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.home-card-header h3 {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.12rem;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.home-card-header a {
+  color: var(--accent2);
+  text-decoration: none;
+  font-size: 13px;
+}
+
+.home-card-body {
+  padding: 4px 16px 8px;
+}
+
+.activity-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  border-bottom: 1px solid var(--border);
+}
+
+.activity-row:last-child {
+  border-bottom: none;
+}
+
+.activity-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+.activity-dot.is-recent {
+  opacity: 1;
+  background: var(--accent2);
+}
+
+.activity-description {
+  flex: 1;
+}
+
+.activity-time {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.quick-actions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+}
+
+.quick-action-btn {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  text-decoration: none;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.quick-action-btn span:last-child {
+  margin-left: auto;
+}
+
 @keyframes fadeIn {
   from {
     opacity: 0;
   }
+
   to {
     opacity: 1;
   }
@@ -992,6 +1189,7 @@ a {
     transform: translateY(20px);
     opacity: 0;
   }
+
   to {
     transform: translateY(0);
     opacity: 1;
@@ -1103,6 +1301,8 @@ a {
   .pagination-current {
     text-align: center;
     padding: 8px 0;
+  }
+
   .modal-dialog {
     width: 95%;
     margin: 16px;
@@ -1114,5 +1314,25 @@ a {
 
   .modal-footer .btn {
     width: 100%;
+  }
+
+  .home-hero {
+    padding: 24px 18px 20px;
+  }
+
+  .home-stats {
+    flex-wrap: wrap;
+    gap: 14px;
+  }
+
+  .home-stat {
+    border-right: none;
+    padding: 0;
+    min-width: calc(50% - 7px);
+  }
+
+  .home-grid {
+    grid-template-columns: 1fr;
+    padding: 16px;
   }
 }

--- a/src/views/home/index-content.ejs
+++ b/src/views/home/index-content.ejs
@@ -1,0 +1,58 @@
+<section class="home-hero" aria-label="Collection overview">
+  <p class="home-hero-tag">Welcome back, <%= username %></p>
+  <h2 class="home-hero-title">YOUR COLLECTION</h2>
+  <p class="home-hero-subtitle">Everything in one place. Here's your latest activity and a snapshot of the collection.</p>
+
+  <div class="home-stats" role="list" aria-label="Collection statistics">
+    <div class="home-stat" role="listitem">
+      <span class="home-stat-value"><%= stats.totalFirearms %></span>
+      <span class="home-stat-label">Firearms</span>
+    </div>
+    <div class="home-stat" role="listitem">
+      <span class="home-stat-value"><%= stats.thisMonth %></span>
+      <span class="home-stat-label">This month</span>
+    </div>
+    <div class="home-stat" role="listitem">
+      <span class="home-stat-value"><%= stats.categories %></span>
+      <span class="home-stat-label">Categories</span>
+    </div>
+    <div class="home-stat" role="listitem">
+      <span class="home-stat-value home-stat-value-accent"><%= stats.lastUpdateDays %></span>
+      <span class="home-stat-label">Last update</span>
+    </div>
+  </div>
+</section>
+
+<section class="home-grid" aria-label="Dashboard cards">
+  <article class="home-card">
+    <header class="home-card-header">
+      <h3>Recent Activity</h3>
+      <a href="/firearms">View all →</a>
+    </header>
+    <div class="home-card-body">
+      <% if (!recentActivity.length) { %>
+        <p class="muted-text">No activity yet. Add your first firearm to get started.</p>
+      <% } else { %>
+        <% recentActivity.forEach((activity) => { %>
+          <div class="activity-row">
+            <span class="activity-dot <%= activity.isRecent ? 'is-recent' : '' %>" aria-hidden="true"></span>
+            <span class="activity-description"><%= activity.description %></span>
+            <span class="activity-time"><%= activity.timeAgo %></span>
+          </div>
+        <% }) %>
+      <% } %>
+    </div>
+  </article>
+
+  <article class="home-card">
+    <header class="home-card-header">
+      <h3>Quick Actions</h3>
+    </header>
+    <div class="home-card-body quick-actions-list">
+      <a class="quick-action-btn" href="/firearms/new"><span>➕ Add new firearm</span><span>→</span></a>
+      <a class="quick-action-btn" href="/firearms"><span>📋 View inventory</span><span>→</span></a>
+      <a class="quick-action-btn" href="/report"><span>🚩 Report an issue</span><span>→</span></a>
+      <a class="quick-action-btn" href="/profile"><span>⚙️ Profile settings</span><span>→</span></a>
+    </div>
+  </article>
+</section>

--- a/src/views/home/index.ejs
+++ b/src/views/home/index.ejs
@@ -1,0 +1,4 @@
+<%
+  const content = include('./index-content', locals);
+%>
+<%- include('../partials/layout', { ...locals, body: content, pageTitle: 'Home', pageClass: 'page-home' }) %>

--- a/src/views/partials/layout.ejs
+++ b/src/views/partials/layout.ejs
@@ -4,9 +4,12 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= pageTitle ? pageTitle + ' — ' : '' %>Pew Pew Collection</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/static/css/styles.css">
 </head>
-<body>
+<body class="<%= typeof pageClass !== 'undefined' ? pageClass : '' %>">
   <% if (csrfToken) { %>
   <input type="hidden" name="_csrf" value="<%= csrfToken %>" id="csrf-token">
   <% } %>

--- a/tests/unit/home.service.test.js
+++ b/tests/unit/home.service.test.js
@@ -1,0 +1,51 @@
+const { createHomeService } = require('../../src/features/home/home.service');
+
+describe('home service', () => {
+  test('builds dashboard data with summary and recent activity labels', () => {
+    const now = Date.now();
+    const oneHourAgo = new Date(now - 60 * 60 * 1000).toISOString().replace('T', ' ').slice(0, 19);
+    const twoDaysAgo = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString().replace('T', ' ').slice(0, 19);
+
+    const firearmsRepository = {
+      getCollectionSummary: jest.fn(() => ({
+        total_firearms: 24,
+        this_month: 3,
+        categories: 6,
+        last_update_days: 2
+      })),
+      getRecentActivity: jest.fn(() => ([
+        {
+          id: 1,
+          make: 'Glock',
+          model: '19 Gen 5',
+          created_at: oneHourAgo,
+          updated_at: oneHourAgo
+        },
+        {
+          id: 2,
+          make: 'Remington',
+          model: '870',
+          created_at: twoDaysAgo,
+          updated_at: oneHourAgo
+        }
+      ]))
+    };
+
+    const service = createHomeService(firearmsRepository);
+    const result = service.getDashboard('admin');
+
+    expect(result.username).toBe('admin');
+    expect(result.stats).toEqual({
+      totalFirearms: 24,
+      thisMonth: 3,
+      categories: 6,
+      lastUpdateDays: '2d'
+    });
+
+    expect(result.recentActivity[0].description).toBe('Added Glock 19 Gen 5');
+    expect(result.recentActivity[0].isRecent).toBe(true);
+    expect(result.recentActivity[1].description).toBe('Updated Remington 870');
+
+    expect(firearmsRepository.getRecentActivity).toHaveBeenCalledWith(5);
+  });
+});


### PR DESCRIPTION
### Motivation
- Deliver a polished authenticated dashboard landing that matches the requested hero visual (full-width strip, uppercase title, amber glow) and does not break other routes or views. 
- Repair CSS and layout regressions introduced earlier that caused rendering errors and failing integration tests. 

### Description
- Add the Home feature layer including `home.service`, `home.controller`, and `home.routes` and wire them into app registration so `/` and `/home` render the dashboard under the auth guard. 
- Implement server-rendered home views (`src/views/home/index.ejs` and `index-content.ejs`) that present stats, recent activity, and quick actions with the updated uppercase hero heading. 
- Extend `firearms.repository` with `getCollectionSummary` and `getRecentActivity` to provide dashboard data, and convert layout handling to a page-scoped class by making `layout.ejs` safely accept an optional `pageClass`. 
- Repair and refactor dashboard-related CSS in `src/public/css/styles.css` (hero strip, amber radial glow, responsive grid/mobile overrides, and pagination/modal fixes) and update the integration assertion to match the new heading text. 

### Testing
- Ran the full test suite with `npm test` and all test suites passed (7 passed, 49 tests). 
- Captured a post-login dashboard screenshot via an automated Playwright script and stored it as an artifact at `browser:/tmp/codex_browser_invocations/def0163e00cd3318/artifacts/artifacts/home-dashboard.png`. 
- Unit test added: `tests/unit/home.service.test.js`, and integration test updated: `tests/integration/auth.integration.test.js`, both exercised and passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999094b4b5883329be48fe5bebac558)