### PR TITLE
Add UI/UX Review Deliverable Standard to UI agent and add audit plan doc

### DIFF
--- a/.github/agents/ui-eng.md
+++ b/.github/agents/ui-eng.md
@@ -8,6 +8,7 @@ You are the primary assistant for UI development and user-experience improvement
 Begin every interaction by:
 1. Clarifying the user-facing behavior or visual outcome that is desired.
 2. Inspecting relevant EJS templates, CSS, and any client-side JavaScript before proposing changes.
+3. Listing the exact pages/routes in scope and explicitly confirming coverage before concluding.
 
 Your goal is to improve usability, accessibility, visual consistency, and maintainable UI patterns while respecting the project's no-build, server-rendered architecture.
 
@@ -71,6 +72,44 @@ When visual clarity matters:
 - Provide **annotated screenshots** explaining layout issues
 - Include before/after comparisons for UI refinements
 - Test in both themes and on mobile viewport
+
+## UI/UX Review Deliverable Standard
+When the user requests a UI/UX review or audit, do **not** return only high-level observations. Provide an implementation-ready artifact that includes:
+
+1. **Page inventory**
+   - Enumerate every page reviewed (route + template path)
+   - Mark whether each page was reviewed in dark mode, light mode, and mobile viewport
+
+2. **Issue register**
+   - One row per issue with: severity (`Critical`, `High`, `Medium`, `Low`), category (`Visual`, `Content`, `Accessibility`, `Interaction`, `Responsive`), affected page, and evidence
+   - Evidence should point to concrete UI elements/classes or template locations, not generic statements
+
+3. **Per-page remediation plan**
+   - For each page, include:
+     - what to change
+     - why it matters
+     - exact files likely touched (`src/views/...`, `src/public/css/styles.css`, optional JS file)
+     - estimated effort (`S`, `M`, `L`)
+
+4. **Acceptance criteria**
+   - Write testable criteria for each planned fix
+   - Include keyboard, screen-reader/ARIA, dark/light, and <=640px behavior checks where applicable
+
+5. **Execution sequencing**
+   - Group fixes into phases (quick wins, structural updates, polish)
+   - Highlight dependencies and risk areas so work can be split across PRs
+
+If any page cannot be reviewed (missing route/data/setup), explicitly call it out as **not reviewed** with the reason.
+
+## Visual and Interaction Quality Bar
+Use this quality bar for recommendations and final checks:
+- **Hierarchy:** clear page title, supporting context, and action priority
+- **Consistency:** spacing, typography scale, button language, empty/error states
+- **Accessibility:** focus visibility, logical tab order, semantic controls, color contrast, dialog behavior
+- **Responsiveness:** no clipped controls, no horizontal overflow, touch targets >=44px
+- **Theme integrity:** equivalent readability and affordances in dark and light themes
+
+Avoid vague guidance such as "improve spacing" or "polish UI" without concrete implementation direction.
 
 ## CSS Guidelines (from AGENTS.md)
 - **ALL styles in `styles.css`:** Never add inline styles to EJS templates

--- a/docs/ui-ux-audit-plan.md
+++ b/docs/ui-ux-audit-plan.md
@@ -1,0 +1,218 @@
+# UI/UX Review and Remediation Plan
+
+## Review Scope
+
+This audit covers every user-facing EJS page currently in the app:
+
+- Home dashboard (`/`)
+- Inventory list (`/firearms`)
+- Add firearm (`/firearms/new`)
+- Edit firearm (`/firearms/:id/edit`)
+- Firearm detail (`/firearms/:id`)
+- Login (`/login`)
+- Forced password change (`/change-password`)
+- Profile settings (`/profile`)
+- 404 page
+
+---
+
+## Cross-Page Inconsistencies (Global)
+
+### 1) Inconsistent page framing and headings
+**Issue**
+- Some pages use a clear hero/title pattern (`Profile Settings`), while others start abruptly with plain `h2` headers (`New Firearm`, `Edit Firearm`, `Not Found`).
+
+**Impact**
+- Users lose orientation because page hierarchy and context setting vary by route.
+
+**Remediation plan**
+- Standardize all top-level pages on one structure:
+  1. eyebrow (optional)
+  2. `h1`/primary title
+  3. subtitle
+  4. action row (if needed)
+- Introduce shared utility classes (e.g., `page-header`, `page-header-actions`) and apply consistently.
+- Ensure one clear primary heading per page.
+
+### 2) Button and action language varies by page
+**Issue**
+- Similar intents use different labels (`Save`, `Save Password`, `Create`, `+ Add Firearm`, `View all →`).
+
+**Impact**
+- Increases cognitive load and makes workflows feel uneven.
+
+**Remediation plan**
+- Create a copy standard for actions:
+  - Primary submit: `Save changes` / `Create firearm` / `Update firearm`
+  - Secondary nav: `Back to inventory`
+  - Destructive: `Delete firearm`
+- Update labels to be intent-specific and consistent.
+
+### 3) Layout patterns are mixed (cards, full-width sections, plain text)
+**Issue**
+- Most pages use cards, but 404 and some form pages are minimally styled.
+
+**Impact**
+- Product feels less cohesive and lower trust on edge-case pages.
+
+**Remediation plan**
+- Define canonical layout variants:
+  - Auth card layout
+  - Form page layout
+  - Detail page layout
+  - Empty/error state layout
+- Convert outlier pages to one of these variants.
+
+### 4) Inline style usage still exists
+**Issue**
+- Some templates still include inline style attributes.
+
+**Impact**
+- Violates maintainability conventions and creates style drift risk.
+
+**Remediation plan**
+- Replace inline style attributes with reusable CSS classes in `styles.css`.
+- Add a lint/check step (or lightweight code review checklist item) to block new inline styles.
+
+### 5) Interaction/accessibility polish is inconsistent
+**Issue**
+- Several clickable patterns are good, but some interactive elements lack full keyboard/modal behavior consistency.
+
+**Impact**
+- Keyboard and assistive-tech users can have uneven experiences.
+
+**Remediation plan**
+- Standardize interaction contracts:
+  - Dialog: focus trap, ESC close, initial focus target, focus return.
+  - Clickable rows: visible focus + explicit action affordance.
+  - External links: clear external indicator and accessible label.
+
+---
+
+## Page-by-Page Findings and Remediation
+
+## 1) Home Dashboard (`/`)
+### Findings
+- Strong visual identity differs significantly from other pages (hero typography + dashboard cards vs standard card/form rhythm).
+- Quick actions and main navigation overlap semantically (e.g., Inventory/Add links in two places).
+
+### Remediation
+- Keep dashboard style, but align spacing, heading scale, and button styling with app-wide tokens.
+- Prioritize one primary quick action and reduce redundant links.
+- Add optional "Recent activity empty state" illustration/icon treatment consistent with global empty states.
+
+## 2) Inventory List (`/firearms`)
+### Findings
+- Action button group uses inline style instead of shared utility class.
+- Dense filter area competes with the main table for visual attention.
+- Row-level clickability plus a "View" button can feel duplicated.
+
+### Remediation
+- Replace inline style with `.action-group` class.
+- Visually group filters into collapsible/secondary region on smaller viewports.
+- Choose one dominant row interaction model:
+  - Either full-row click with trailing chevron
+  - Or explicit "View" action only.
+
+## 3) Add Firearm (`/firearms/new`)
+### Findings
+- Page opens with plain heading; lacks contextual subtitle/help compared with profile pages.
+- Form action row appears at bottom only; long forms benefit from top context and sticky actions.
+
+### Remediation
+- Add standardized page header (`Add firearm`, short guidance).
+- Add helper text for required fields near form start (not only per-field).
+- Consider sticky action bar on desktop for long-form completion.
+
+## 4) Edit Firearm (`/firearms/:id/edit`)
+### Findings
+- Similar structure to Add page but lacks explicit context that user is editing an existing record.
+- No quick summary of current firearm identity above form fields.
+
+### Remediation
+- Add page header with firearm identity (make/model + secondary metadata chips).
+- Add "Last updated" metadata where available.
+- Mirror Add page improvements for consistency.
+
+## 5) Firearm Detail (`/firearms/:id`)
+### Findings
+- Good card/detail grouping, but modal interaction can be improved.
+- Delete form currently includes inline style.
+- Actions are numerous and near each other (Edit/Delete/Duplicate/Print), increasing misclick risk.
+
+### Remediation
+- Replace inline form style with class-based utility.
+- Improve destructive action separation:
+  - Place delete in a danger zone section
+  - Keep edit/duplicate/print in primary toolbar.
+- Upgrade modal a11y behavior (ESC, focus trap, focus return).
+
+## 6) Login (`/login`)
+### Findings
+- Clean and focused, but lacks password assistance affordances (show/hide, caps lock hint, forgot path if applicable).
+
+### Remediation
+- Add optional show/hide password toggle.
+- Add lightweight inline validation/error placement tied to field context.
+- Ensure auto-focus and enter-key flow are optimized.
+
+## 7) Forced Password Change (`/change-password`)
+### Findings
+- Similar to login card but includes additional security messaging.
+- Field guidance appears in title text and paragraph; could be made more structured.
+
+### Remediation
+- Convert requirements into checklist-style helper (`12+ chars`, confirm match, etc.).
+- Add live feedback for password match strength/confirmation.
+- Align layout and spacing with profile password card for consistency.
+
+## 8) Profile (`/profile`)
+### Findings
+- Strong card-based organization.
+- Different save button labels within same area (`Save` vs `Save Password`) create minor inconsistency.
+
+### Remediation
+- Normalize action labels to clear intent (`Save username`, `Save theme`, `Save password`).
+- Add section-level success messaging that persists briefly and then dismisses.
+- Consider tabs/accordion on mobile to reduce vertical scroll burden.
+
+## 9) 404 Page
+### Findings
+- Very minimal presentation and not aligned with visual quality of main app pages.
+
+### Remediation
+- Convert to styled empty/error state card:
+  - friendly title
+  - brief explanation
+  - primary CTA (`Back home`) and secondary CTA (`Go to inventory`).
+- Add optional error illustration/icon consistent with theme.
+
+---
+
+## Prioritized Execution Plan
+
+### Phase 1 — Consistency Foundation (High impact, low risk)
+1. Remove all inline style attributes and replace with CSS classes.
+2. Standardize page headers (title/subtitle/action row).
+3. Normalize button copy across CRUD/auth/settings pages.
+4. Refresh 404 into a styled error state.
+
+### Phase 2 — Interaction and Accessibility (High impact, medium effort)
+1. Improve modal accessibility behavior and keyboard support.
+2. Reconcile table row click behavior vs explicit row action.
+3. Add password usability enhancements on login/change-password/profile.
+
+### Phase 3 — Workflow Optimization (Medium impact, medium effort)
+1. Improve add/edit form ergonomics (context block, sticky actions).
+2. Refine dashboard quick actions to reduce duplicate navigation.
+3. Introduce consistent empty-state visuals and messaging patterns.
+
+---
+
+## Validation Checklist for Remediation Work
+
+- Visual consistency in both dark and light themes.
+- Mobile checks at <=640px for every page template.
+- Keyboard-only navigation for navbar, forms, table rows, and modal dialogs.
+- Clear destructive action separation and confirmation for delete flows.
+- No inline styles in EJS templates.


### PR DESCRIPTION
### Motivation
- Make the UI engineering assistant prescribe exact page coverage and a repeatable, implementation-ready UI/UX review output. 
- Reduce ambiguity in audits by requiring concrete artifacts (page inventory, issue register, remediation plans, acceptance criteria, execution sequencing). 
- Provide a working audit example and remediation roadmap so UI fixes can be executed consistently across the app.

### Description
- Update `.github/agents/ui-eng.md` to require the agent to list exact pages/routes in scope and to add a `UI/UX Review Deliverable Standard` that specifies required audit artifacts and quality checks. 
- Expand guidance with explicit expectations for page inventories, issue registers, per-page remediation plans, acceptance criteria, and phased execution sequencing. 
- Add `docs/ui-ux-audit-plan.md` as a concrete, repository-hosted UI/UX audit covering all user-facing pages with findings, remediation steps, prioritized phases, and a validation checklist.

### Testing
- No automated tests were added or executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac2524530483328a22b015dd44d63b)