### PR TITLE
ci(release): fail Trivy gate on critical vulnerabilities only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ppcollection:scan-${{ github.sha }}
-          severity: CRITICAL,HIGH
+          severity: CRITICAL
           exit-code: '1'
           format: table
           output: trivy-results.txt


### PR DESCRIPTION
### Motivation
- Reduce release pipeline failures caused by `HIGH` severity findings while preserving a strict gate for `CRITICAL` vulnerabilities.

### Description
- Update the Trivy step in ` .github/workflows/release.yml` to use `severity: CRITICAL` instead of `CRITICAL,HIGH` while keeping `exit-code: '1'` and leaving the report upload behavior unchanged.

### Testing
- No automated tests were run for this YAML-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb0cd21848332ac21d4ac9ae7a6a7)