### PR TITLE
fix(auth): add conditional secure cookie support via SECURE_COOKIES env var

### DIFF
--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -34,3 +34,4 @@ Response style:
 - distinguish evidence from inference when needed
 - keep summaries brief
 - if no findings, say so explicitly and mention residual risks or missing tests
+"""

--- a/README.md
+++ b/README.md
@@ -41,13 +41,23 @@ Open `http://localhost:3000`. On first login you will be prompted to change the 
 
 ## Configuration
 
-| Variable | Default | Description |
-|---|---|---|
-| `SESSION_SECRET` | `ppcollection_dev_secret` | **Required in production.** Generate with `openssl rand -hex 32` |
-| `ADMIN_USERNAME` | `admin` | Username for the admin account |
-| `ADMIN_PASSWORD` | `changeme` | Initial password — a change is forced on first login |
-| `PORT` | `3000` | HTTP port the server listens on |
-| `DATABASE_PATH` | `/data/app.db` | Path to the SQLite database file |
+| Variable | Purpose | Default | Notes |
+|---|---|---|---|
+| `SESSION_SECRET` | Session signing secret | `ppcollection_dev_secret` | **Required in production.** Generate with `openssl rand -hex 32` |
+| `ADMIN_USERNAME` | Username for the admin account | `admin` | Used for initial login |
+| `ADMIN_PASSWORD` | Initial admin password | `changeme` | A change is forced on first login |
+| `PORT` | HTTP port the server listens on | `3000` | Runtime server port |
+| `DATABASE_PATH` | Path to the SQLite database file | `/data/app.db` | Defaults to `/data` in Docker |
+| `TRUST_PROXY` | Trust `X-Forwarded-Proto` from a reverse proxy | `false` | Set to `true` when running behind nginx, Caddy, or Traefik |
+| `SECURE_COOKIES` | Set the `Secure` flag on session cookies | `false` | Requires `TRUST_PROXY=true`; only enable when HTTPS is in use |
+
+## Security Notes
+
+> **Reverse proxy users:** If you are running PPCollection behind nginx,
+> Caddy, or Traefik with HTTPS, set `TRUST_PROXY=true` and
+> `SECURE_COOKIES=true` to enable full cookie security. Do not set
+> `SECURE_COOKIES=true` without a working HTTPS reverse proxy — sessions
+> will silently break.
 
 ## Screenshots
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,12 @@ services:
       - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-changeme}
       - DATABASE_PATH=/data/app.db
+      # Uncomment the two lines below if you are running behind an HTTPS reverse proxy
+      # - TRUST_PROXY=true
+      # - SECURE_COOKIES=true
     volumes:
       - ./data:/data
     restart: unless-stopped
 
 volumes:
   data:
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppcollection",
-  "version": "1.15.9",
+  "version": "1.15.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ppcollection",
-      "version": "1.15.9",
+      "version": "1.15.11",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -51,7 +51,7 @@ async function createApp(options = {}) {
   app.locals.db = db;
 
   if (config.trustProxy) {
-    app.set('trust proxy', 1);
+    app.set('trust proxy', true);
   }
 
   app.use(helmet());
@@ -69,7 +69,7 @@ async function createApp(options = {}) {
         maxAge: 1000 * 60 * 60 * 8,
         httpOnly: true,
         sameSite: 'lax',
-        secure: config.secureCookies
+        secure: !!config.secureCookies
       }
     })
   );
@@ -88,7 +88,7 @@ async function createApp(options = {}) {
     cookieOptions: {
       sameSite: 'lax',
       path: '/',
-      secure: false,
+      secure: !!config.secureCookies,
       httpOnly: true
     },
     size: 64,

--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -50,6 +50,10 @@ async function createApp(options = {}) {
 
   app.locals.db = db;
 
+  if (config.trustProxy) {
+    app.set('trust proxy', 1);
+  }
+
   app.use(helmet());
   app.use(cookieParser());
   app.use(express.json());
@@ -61,7 +65,12 @@ async function createApp(options = {}) {
       secret: config.sessionSecret,
       resave: false,
       saveUninitialized: false,
-      cookie: { maxAge: 1000 * 60 * 60 * 8 }
+      cookie: {
+        maxAge: 1000 * 60 * 60 * 8,
+        httpOnly: true,
+        sameSite: 'lax',
+        secure: config.secureCookies
+      }
     })
   );
 

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -6,7 +6,9 @@ function getConfig() {
     sessionSecret: process.env.SESSION_SECRET || 'ppcollection_dev_secret',
     adminUser: process.env.ADMIN_USERNAME || 'admin',
     adminPass: process.env.ADMIN_PASSWORD || 'changeme',
-    databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db')
+    databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db'),
+    trustProxy: process.env.TRUST_PROXY === 'true',
+    secureCookies: process.env.SECURE_COOKIES === 'true'
   };
 }
 

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -1,14 +1,25 @@
 const path = require('path');
 
 function getConfig() {
+  const trustProxy = process.env.TRUST_PROXY === 'true';
+  const secureCookies = process.env.SECURE_COOKIES === 'true';
+
+  if (secureCookies && !trustProxy) {
+    console.warn(
+      '[config] WARNING: SECURE_COOKIES=true but TRUST_PROXY is not enabled. ' +
+        'Secure cookies require Express to recognize the request as HTTPS (trust proxy). ' +
+        'Sessions may fail to persist. Set TRUST_PROXY=true when running behind an HTTPS reverse proxy.'
+    );
+  }
+
   return {
     port: process.env.PORT ? Number(process.env.PORT) : 3000,
     sessionSecret: process.env.SESSION_SECRET || 'ppcollection_dev_secret',
     adminUser: process.env.ADMIN_USERNAME || 'admin',
     adminPass: process.env.ADMIN_PASSWORD || 'changeme',
     databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db'),
-    trustProxy: process.env.TRUST_PROXY === 'true',
-    secureCookies: process.env.SECURE_COOKIES === 'true'
+    trustProxy,
+    secureCookies
   };
 }
 

--- a/tests/integration/auth.integration.test.js
+++ b/tests/integration/auth.integration.test.js
@@ -597,3 +597,78 @@ describe('auth routes', () => {
     expect(afterLogoutResponse.headers.location).toBe('/login');
   });
 });
+
+describe('cookie security flags', () => {
+  let dbPath;
+
+  afterEach(() => {
+    if (dbPath) {
+      const dir = path.dirname(dbPath);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function secureConfig(databasePath) {
+    return {
+      port: 0,
+      sessionSecret: 'test-secret',
+      adminUser: 'admin',
+      adminPass: 'password123',
+      databasePath,
+      trustProxy: true,
+      secureCookies: true
+    };
+  }
+
+  test('session cookie has Secure flag when secureCookies=true', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-cookie-'));
+    dbPath = path.join(tempDir, 'app.db');
+    const app = await createApp({ config: secureConfig(dbPath) });
+
+    // Simulate a proxied HTTPS request so express-session considers the connection secure
+    const response = await request(app).get('/login').set('X-Forwarded-Proto', 'https');
+
+    const cookies = response.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    const sessionCookie = cookies.find((c) => c.startsWith('connect.sid'));
+    expect(sessionCookie).toBeDefined();
+    expect(sessionCookie.toLowerCase()).toContain('secure');
+    expect(sessionCookie.toLowerCase()).toContain('httponly');
+
+    app.locals.db.close();
+  });
+
+  test('CSRF cookie has Secure flag when secureCookies=true', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-cookie-'));
+    dbPath = path.join(tempDir, 'app.db');
+    const app = await createApp({ config: secureConfig(dbPath) });
+
+    // Simulate a proxied HTTPS request so csrf-csrf sets the Secure attribute on the cookie
+    const response = await request(app).get('/login').set('X-Forwarded-Proto', 'https');
+
+    const cookies = response.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    const csrfCookie = cookies.find((c) => c.startsWith('x-csrf-token'));
+    expect(csrfCookie).toBeDefined();
+    expect(csrfCookie.toLowerCase()).toContain('secure');
+    expect(csrfCookie.toLowerCase()).toContain('httponly');
+
+    app.locals.db.close();
+  });
+
+  test('session cookie does NOT have Secure flag when secureCookies=false', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-cookie-'));
+    dbPath = path.join(tempDir, 'app.db');
+    const app = await createApp({ config: testConfig(dbPath) });
+
+    const response = await request(app).get('/login');
+
+    const cookies = response.headers['set-cookie'];
+    expect(cookies).toBeDefined();
+    const sessionCookie = cookies.find((c) => c.startsWith('connect.sid'));
+    expect(sessionCookie).toBeDefined();
+    expect(sessionCookie.toLowerCase()).not.toContain('secure');
+
+    app.locals.db.close();
+  });
+});


### PR DESCRIPTION
This pull request enhances the application's security and configuration flexibility, especially for deployments behind HTTPS reverse proxies. It introduces new environment variables for proxy and cookie security, updates documentation, and adjusts server behavior to support secure session handling.

Configuration and Security Improvements:

* Added support for two new environment variables, `TRUST_PROXY` and `SECURE_COOKIES`, to enable secure cookie handling when running behind HTTPS reverse proxies. These are now parsed in the configuration loader (`src/infra/config/index.js`).
* Updated the Express app initialization to respect the `trustProxy` setting, enabling proxy-aware behavior when needed (`src/app/createApp.js`).
* Enhanced session cookie configuration to support `httpOnly`, `sameSite: 'lax'`, and conditional `secure` flags based on the new `secureCookies` setting, improving session security (`src/app/createApp.js`).

Documentation Updates:

* Expanded the environment variable table in `README.md` to describe the new variables and added a dedicated Security Notes section explaining how to configure the app securely behind a reverse proxy.
* Added commented instructions in `docker-compose.yml` for enabling the new proxy and cookie security settings when running behind an HTTPS reverse proxy.

Other:

* Minor formatting fix in `.codex/agents/reviewer.toml` to close a multi-line string.