### PR TITLE
feat(firearms): add disposition fields for transfer and sale tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ppcollection",
-  "version": "1.15.9",
+  "version": "1.15.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ppcollection",
-      "version": "1.15.9",
+      "version": "1.15.11",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "bcrypt": "^6.0.0",

--- a/src/features/firearms/firearms.service.js
+++ b/src/features/firearms/firearms.service.js
@@ -10,6 +10,10 @@ const CSV_HEADERS = [
   'Condition',
   'Location',
   'Status',
+  'Disposition Name',
+  'Disposition Address',
+  'Disposition Date',
+  'Disposition Reason',
   'Firearm Type',
   'Gun Warranty',
   'Notes'
@@ -57,6 +61,10 @@ function createFirearmsService(firearmsRepository) {
           item.condition || '',
           item.location || '',
           item.status || '',
+          item.disposition_name || '',
+          item.disposition_address || '',
+          item.disposition_date || '',
+          item.disposition_reason || '',
           item.firearm_type || '',
           warrantyLabel,
           item.notes || ''

--- a/src/features/firearms/firearms.service.js
+++ b/src/features/firearms/firearms.service.js
@@ -1,4 +1,5 @@
 const { toCsv } = require('../../shared/utils/csv');
+const { isDispositionStatus } = require('./firearms.validators');
 
 const CSV_HEADERS = [
   'Make',
@@ -51,6 +52,8 @@ function createFirearmsService(firearmsRepository) {
         if (item.gun_warranty === 1) warrantyLabel = 'Yes';
         else if (item.gun_warranty === 0) warrantyLabel = 'No';
 
+        const isDisposition = isDispositionStatus(item.status);
+
         return [
           item.make || '',
           item.model || '',
@@ -61,10 +64,10 @@ function createFirearmsService(firearmsRepository) {
           item.condition || '',
           item.location || '',
           item.status || '',
-          item.disposition_name || '',
-          item.disposition_address || '',
-          item.disposition_date || '',
-          item.disposition_reason || '',
+          isDisposition ? item.disposition_name || '' : '',
+          isDisposition ? item.disposition_address || '' : '',
+          isDisposition ? item.disposition_date || '' : '',
+          isDisposition ? item.disposition_reason || '' : '',
           item.firearm_type || '',
           warrantyLabel,
           item.notes || ''

--- a/src/features/firearms/firearms.validators.js
+++ b/src/features/firearms/firearms.validators.js
@@ -9,6 +9,10 @@ function sanitizeFirearmInput(body) {
     condition: (body.condition || '').trim(),
     location: (body.location || '').trim(),
     status: (body.status || '').trim(),
+    disposition_name: (body.disposition_name || '').trim(),
+    disposition_address: (body.disposition_address || '').trim(),
+    disposition_date: (body.disposition_date || '').trim(),
+    disposition_reason: (body.disposition_reason || '').trim(),
     notes: (body.notes || '').trim(),
     gun_warranty: body.gun_warranty ? 1 : 0,
     firearm_type: (body.firearm_type || '').trim()

--- a/src/features/firearms/firearms.validators.js
+++ b/src/features/firearms/firearms.validators.js
@@ -1,4 +1,12 @@
+const DISPOSITION_STATUSES = new Set(['sold', 'lost/stolen', 'lost', 'stolen']);
+
+function isDispositionStatus(status) {
+  return DISPOSITION_STATUSES.has(String(status || '').trim().toLowerCase());
+}
+
 function sanitizeFirearmInput(body) {
+  const status = (body.status || '').trim();
+
   return {
     make: (body.make || '').trim(),
     model: (body.model || '').trim(),
@@ -8,11 +16,11 @@ function sanitizeFirearmInput(body) {
     purchase_price: body.purchase_price ? Number(body.purchase_price) : null,
     condition: (body.condition || '').trim(),
     location: (body.location || '').trim(),
-    status: (body.status || '').trim(),
-    disposition_name: (body.disposition_name || '').trim(),
-    disposition_address: (body.disposition_address || '').trim(),
-    disposition_date: (body.disposition_date || '').trim(),
-    disposition_reason: (body.disposition_reason || '').trim(),
+    status,
+    disposition_name: isDispositionStatus(status) ? (body.disposition_name || '').trim() : '',
+    disposition_address: isDispositionStatus(status) ? (body.disposition_address || '').trim() : '',
+    disposition_date: isDispositionStatus(status) ? (body.disposition_date || '').trim() : '',
+    disposition_reason: isDispositionStatus(status) ? (body.disposition_reason || '').trim() : '',
     notes: (body.notes || '').trim(),
     gun_warranty: body.gun_warranty ? 1 : 0,
     firearm_type: (body.firearm_type || '').trim()
@@ -40,4 +48,4 @@ function validateFirearmInput(data) {
   };
 }
 
-module.exports = { sanitizeFirearmInput, validateFirearmInput };
+module.exports = { sanitizeFirearmInput, validateFirearmInput, isDispositionStatus };

--- a/src/infra/db/migrations/003_disposition_fields.sql
+++ b/src/infra/db/migrations/003_disposition_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE firearms ADD COLUMN disposition_name TEXT;
+ALTER TABLE firearms ADD COLUMN disposition_address TEXT;
+ALTER TABLE firearms ADD COLUMN disposition_date TEXT;
+ALTER TABLE firearms ADD COLUMN disposition_reason TEXT;

--- a/src/infra/db/repositories/firearms.repository.js
+++ b/src/infra/db/repositories/firearms.repository.js
@@ -25,6 +25,10 @@ function createFirearmsRepository(db) {
           condition,
           location,
           status,
+          disposition_name,
+          disposition_address,
+          disposition_date,
+          disposition_reason,
           notes,
           gun_warranty,
           firearm_type
@@ -39,12 +43,22 @@ function createFirearmsRepository(db) {
           @condition,
           @location,
           @status,
+          @disposition_name,
+          @disposition_address,
+          @disposition_date,
+          @disposition_reason,
           @notes,
           @gun_warranty,
           @firearm_type
         )
       `);
-      const info = stmt.run(data);
+      const info = stmt.run({
+        disposition_name: '',
+        disposition_address: '',
+        disposition_date: '',
+        disposition_reason: '',
+        ...data
+      });
       return info.lastInsertRowid;
     },
     update(id, data) {
@@ -60,13 +74,24 @@ function createFirearmsRepository(db) {
           condition = @condition,
           location = @location,
           status = @status,
+          disposition_name = @disposition_name,
+          disposition_address = @disposition_address,
+          disposition_date = @disposition_date,
+          disposition_reason = @disposition_reason,
           notes = @notes,
           gun_warranty = @gun_warranty,
           firearm_type = @firearm_type,
           updated_at = datetime('now')
         WHERE id = @id
       `);
-      stmt.run({ ...data, id });
+      stmt.run({
+        disposition_name: '',
+        disposition_address: '',
+        disposition_date: '',
+        disposition_reason: '',
+        ...data,
+        id
+      });
     },
     remove(id) {
       db.prepare('DELETE FROM firearms WHERE id = ?').run(id);

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -674,6 +674,10 @@ h3 {
   color: var(--text-muted);
 }
 
+.hidden {
+  display: none;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;

--- a/src/views/firearms/_form.ejs
+++ b/src/views/firearms/_form.ejs
@@ -69,6 +69,30 @@
     <small class="helper-text">Current ownership or maintenance state.</small>
   </label>
 </div>
+<div class="col-span-2 disposition-section">
+  <div class="grid">
+    <div>
+      <label>Transferred/Sold To
+        <input name="disposition_name" value="<%= item.disposition_name || '' %>">
+      </label>
+    </div>
+    <div>
+      <label>Address
+        <input name="disposition_address" value="<%= item.disposition_address || '' %>">
+      </label>
+    </div>
+    <div>
+      <label>Date of Transfer
+        <input type="date" name="disposition_date" value="<%= item.disposition_date || '' %>">
+      </label>
+    </div>
+    <div>
+      <label>Reason
+        <input name="disposition_reason" placeholder="e.g., Sold, Lost, Stolen, Transferred" value="<%= item.disposition_reason || '' %>">
+      </label>
+    </div>
+  </div>
+</div>
 <div>
   <label>Firearm Type
     <select name="firearm_type">
@@ -96,3 +120,21 @@
     <textarea name="notes" rows="4"><%= item.notes || '' %></textarea>
   </label>
   </div>
+
+<script>
+(function () {
+  const statusSelect = document.querySelector('select[name="status"]');
+  const dispositionSection = document.querySelector('.disposition-section');
+
+  function toggleDisposition() {
+    const showStatuses = ['Sold', 'Lost/Stolen'];
+    const show = showStatuses.includes(statusSelect.value);
+    dispositionSection.classList.toggle('hidden', !show);
+  }
+
+  if (statusSelect && dispositionSection) {
+    statusSelect.addEventListener('change', toggleDisposition);
+    toggleDisposition();
+  }
+})();
+</script>

--- a/src/views/firearms/_form.ejs
+++ b/src/views/firearms/_form.ejs
@@ -69,7 +69,7 @@
     <small class="helper-text">Current ownership or maintenance state.</small>
   </label>
 </div>
-<div class="col-span-2 disposition-section">
+<div class="col-span-2 disposition-section <%= (item.status === 'Sold' || item.status === 'Lost/Stolen') ? '' : 'hidden' %>">
   <div class="grid">
     <div>
       <label>Transferred/Sold To
@@ -130,6 +130,9 @@
     const showStatuses = ['Sold', 'Lost/Stolen'];
     const show = showStatuses.includes(statusSelect.value);
     dispositionSection.classList.toggle('hidden', !show);
+    dispositionSection.querySelectorAll('input').forEach(function (input) {
+      input.disabled = !show;
+    });
   }
 
   if (statusSelect && dispositionSection) {

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -64,6 +64,18 @@
       </dl>
     </section>
 
+    <% if (item.status === 'Sold' || item.status === 'Lost/Stolen') { %>
+      <section class="detail-card panel">
+        <p class="section-header label-caps">Disposition</p>
+        <dl class="details">
+          <dt class="label-caps">Transferred To</dt><dd><%= item.disposition_name || '-' %></dd>
+          <dt class="label-caps">Address</dt><dd><%= item.disposition_address || '-' %></dd>
+          <dt class="label-caps">Date</dt><dd class="mono"><%= item.disposition_date || '-' %></dd>
+          <dt class="label-caps">Reason</dt><dd><%= item.disposition_reason || '-' %></dd>
+        </dl>
+      </section>
+    <% } %>
+
     <section class="detail-card detail-card-full panel">
       <p class="section-header label-caps">Notes</p>
       <pre class="notes mono"><%= item.notes || '-' %></pre>

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -64,7 +64,11 @@
       </dl>
     </section>
 
-    <% if (item.status === 'Sold' || item.status === 'Lost/Stolen') { %>
+    <% function isDispositionStatus(value) {
+      const n = String(value || '').trim().toLowerCase();
+      return n === 'sold' || n === 'lost/stolen' || n === 'lost' || n === 'stolen';
+    } %>
+    <% if (isDispositionStatus(item.status)) { %>
       <section class="detail-card panel">
         <p class="section-header label-caps">Disposition</p>
         <dl class="details">

--- a/tests/integration/firearms.integration.test.js
+++ b/tests/integration/firearms.integration.test.js
@@ -225,7 +225,7 @@ describe('firearms routes', () => {
     expect(response.status).toBe(200);
     expect(response.headers['content-type']).toContain('text/csv');
     expect(response.headers['content-disposition']).toMatch(/attachment; filename="firearms-\d{4}-\d{2}-\d{2}\.csv"/);
-    expect(response.text).toContain('Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Firearm Type,Gun Warranty,Notes');
+    expect(response.text).toContain('Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes');
     expect(response.text).toContain('Smith & Wesson,M&P');
   });
 

--- a/tests/integration/load.integration.test.js
+++ b/tests/integration/load.integration.test.js
@@ -222,7 +222,7 @@ describe('load test — 100 firearms', () => {
     // Header row + 100 data rows
     const lines = response.text.trim().split('\n');
     expect(lines.length).toBe(101);
-    expect(lines[0]).toBe('Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Firearm Type,Gun Warranty,Notes');
+    expect(lines[0]).toBe('Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes');
   });
 
   test('dashboard reflects correct totals for 100 firearms', async () => {


### PR DESCRIPTION
### Motivation
- Add disposition tracking fields to the `firearms` feature to match the ATF personal firearms record (P3312.8) for transfer/sale/loss tracking.
- Ensure disposition data is captured, persisted, displayed, and exported end-to-end (form → validation → repository → service/CSV → detail view) without breaking existing behaviour.

### Description
- Add a new migration `src/infra/db/migrations/003_disposition_fields.sql` that adds `disposition_name`, `disposition_address`, `disposition_date`, and `disposition_reason` columns to the `firearms` table. 
- Wire the new fields into input sanitization by updating `sanitizeFirearmInput` in `src/features/firearms/firearms.validators.js` and persist them in `create`/`update` in `src/infra/db/repositories/firearms.repository.js` (repository provides empty-string defaults for backwards compatibility). 
- Include disposition columns in CSV export by extending `CSV_HEADERS` and the row mapper in `src/features/firearms/firearms.service.js`. 
- Add a conditional disposition section to the form (`src/views/firearms/_form.ejs`) with vanilla JS to show/hide based on `status`, add a `.hidden` utility class in `src/public/css/styles.css`, and add a conditional disposition detail card to `src/views/firearms/show-content.ejs`; update integration tests to expect the expanded CSV header. 

### Testing
- Ran `npm run lint` and `npm test` (Jest); all test suites passed after updating the integration expectations for the new CSV header. 
- Integration tests were updated (`tests/integration/firearms.integration.test.js` and `tests/integration/load.integration.test.js`) to assert the expanded CSV header and succeeded during the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf06d01940833289ec55d7773189ff)