### PR TITLE
fix(dashboard): show cumulative collection value by year

### DIFF
--- a/src/infra/db/repositories/firearms.repository.js
+++ b/src/infra/db/repositories/firearms.repository.js
@@ -127,13 +127,18 @@ function createFirearmsRepository(db) {
     getValueByYear() {
       return db.prepare(`
         SELECT
-          strftime('%Y', purchase_date) AS year,
-          ROUND(SUM(purchase_price), 2) AS total_value
-        FROM firearms
-        WHERE purchase_date IS NOT NULL
-          AND TRIM(purchase_date) != ''
-          AND purchase_price IS NOT NULL
-        GROUP BY year
+          year,
+          ROUND(SUM(total_value) OVER (ORDER BY year), 2) AS total_value
+        FROM (
+          SELECT
+            strftime('%Y', purchase_date) AS year,
+            SUM(purchase_price) AS total_value
+          FROM firearms
+          WHERE purchase_date IS NOT NULL
+            AND TRIM(purchase_date) != ''
+            AND purchase_price IS NOT NULL
+          GROUP BY year
+        )
         ORDER BY year ASC
       `).all();
     }

--- a/tests/unit/firearms.repository.test.js
+++ b/tests/unit/firearms.repository.test.js
@@ -159,7 +159,7 @@ describe('firearms repository chart queries', () => {
 
     expect(result).toEqual([
       { year: '2023', total_value: 1350 },
-      { year: '2024', total_value: 1100 }
+      { year: '2024', total_value: 2450 }
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- The "Collection Value by Year" chart was showing per-year spend only, causing bars to go up and down
- Replaced the `GROUP BY year` aggregation with a SQLite window function (`SUM() OVER (ORDER BY year)`) so each bar reflects the **cumulative total** value of the collection up to that year
- Updated the repository unit test to assert cumulative values (2023: $1,350 → 2024: $2,450 instead of $1,100)

## Test plan

- [ ] Run `npm test` — all 64 tests pass
- [ ] Open the dashboard and verify the "Collection Value by Year" bars increase monotonically year over year

https://claude.ai/code/session_01NzRA8t2gr9Tx34wLPJj2GU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzRA8t2gr9Tx34wLPJj2GU)_