### PR TITLE
feat(firearms): bulk CSV import with downloadable template

### DIFF
--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -1,4 +1,5 @@
 const { sanitizeFirearmInput, validateFirearmInput } = require('./firearms.validators');
+const { CSV_HEADERS } = require('./firearms.service');
 
 function createFirearmsController(firearmsService) {
   return {
@@ -101,6 +102,25 @@ function createFirearmsController(firearmsService) {
     remove(req, res) {
       firearmsService.remove(req.params.id);
       res.redirect('/firearms');
+    },
+
+    showImport(req, res) {
+      res.render('firearms/import', { results: null });
+    },
+
+    downloadTemplate(req, res) {
+      res.setHeader('Content-Type', 'text/csv');
+      res.setHeader('Content-Disposition', 'attachment; filename="firearms-import-template.csv"');
+      res.send(CSV_HEADERS.join(',') + '\n');
+    },
+
+    importCsv(req, res) {
+      const csvText = typeof req.body === 'string' ? req.body : '';
+      if (!csvText.trim()) {
+        return res.status(400).json({ error: 'No CSV data received.' });
+      }
+      const results = firearmsService.importFromCsv(csvText);
+      return res.json(results);
     }
   };
 }

--- a/src/features/firearms/firearms.routes.js
+++ b/src/features/firearms/firearms.routes.js
@@ -6,6 +6,9 @@ function createFirearmsRoutes(firearmsController) {
 
   router.get('/', requireAuth, firearmsController.list);
   router.get('/export', requireAuth, firearmsController.exportCsv);
+  router.get('/import/template', requireAuth, firearmsController.downloadTemplate);
+  router.get('/import', requireAuth, firearmsController.showImport);
+  router.post('/import', requireAuth, express.text({ limit: '2mb', type: 'text/plain' }), firearmsController.importCsv);
   router.get('/new', requireAuth, firearmsController.showNew);
   router.post('/', requireAuth, firearmsController.create);
   router.get('/:id', requireAuth, firearmsController.show);

--- a/src/features/firearms/firearms.service.js
+++ b/src/features/firearms/firearms.service.js
@@ -1,5 +1,5 @@
-const { toCsv } = require('../../shared/utils/csv');
-const { isDispositionStatus } = require('./firearms.validators');
+const { parseCsv, toCsv } = require('../../shared/utils/csv');
+const { sanitizeFirearmInput, validateFirearmInput, isDispositionStatus } = require('./firearms.validators');
 
 const CSV_HEADERS = [
   'Make',
@@ -46,6 +46,58 @@ function createFirearmsService(firearmsRepository) {
       firearmsRepository.remove(id);
     },
 
+    importFromCsv(csvText) {
+      const rows = parseCsv(csvText);
+      if (rows.length < 2) {
+        return { imported: 0, failed: 0, errors: [] };
+      }
+
+      const headers = rows[0].map((h) => h.trim().toLowerCase());
+      const dataRows = rows.slice(1);
+
+      const col = (name) => headers.indexOf(name);
+
+      let imported = 0;
+      const errors = [];
+
+      for (let i = 0; i < dataRows.length; i++) {
+        const r = dataRows[i];
+        const get = (name) => (r[col(name)] || '').trim();
+
+        const rawWarranty = get('gun warranty');
+        const body = {
+          make: get('make'),
+          model: get('model'),
+          serial: get('serial'),
+          caliber: get('caliber'),
+          purchase_date: get('purchase date'),
+          purchase_price: get('purchase price'),
+          condition: get('condition'),
+          location: get('location'),
+          status: get('status'),
+          disposition_name: get('disposition name'),
+          disposition_address: get('disposition address'),
+          disposition_date: get('disposition date'),
+          disposition_reason: get('disposition reason'),
+          firearm_type: get('firearm type'),
+          gun_warranty: rawWarranty.toLowerCase() === 'yes' ? '1' : '',
+          notes: get('notes')
+        };
+
+        const data = sanitizeFirearmInput(body);
+        const { isValid, fieldErrors } = validateFirearmInput(data);
+
+        if (!isValid) {
+          errors.push({ row: i + 2, errors: Object.values(fieldErrors).join(', ') });
+        } else {
+          firearmsRepository.create(data);
+          imported++;
+        }
+      }
+
+      return { imported, failed: errors.length, errors };
+    },
+
     toCsv(items) {
       const rows = items.map((item) => {
         let warrantyLabel = '';
@@ -79,4 +131,4 @@ function createFirearmsService(firearmsRepository) {
   };
 }
 
-module.exports = { createFirearmsService };
+module.exports = { createFirearmsService, CSV_HEADERS };

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1451,6 +1451,77 @@ h3 {
   }
 }
 
+.import-card {
+  max-width: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.import-instructions {
+  margin: 0;
+}
+
+.upload-area {
+  border: 2px dashed var(--border);
+  border-radius: var(--radius);
+  padding: 2rem 1.5rem;
+  text-align: center;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background 0.2s ease;
+  position: relative;
+}
+
+.upload-area--drag,
+.upload-area:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+.upload-area--selected {
+  border-color: var(--accent);
+}
+
+.upload-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+  width: 100%;
+  height: 100%;
+}
+
+.upload-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  pointer-events: none;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.upload-icon {
+  font-size: 2rem;
+  line-height: 1;
+  color: var(--accent);
+}
+
+.import-summary {
+  margin: 0;
+}
+
+.import-errors {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.import-errors li {
+  margin-bottom: 0.25rem;
+}
+
 @media (max-width: 640px) {
   .settings-grid {
     grid-template-columns: 1fr;

--- a/src/shared/utils/csv.js
+++ b/src/shared/utils/csv.js
@@ -1,3 +1,42 @@
+function parseCsv(text) {
+  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i <= normalized.length; i++) {
+    const ch = normalized[i];
+
+    if (inQuotes) {
+      if (ch === '"' && normalized[i + 1] === '"') {
+        field += '"';
+        i++;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        field += ch ?? '';
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      row.push(field);
+      field = '';
+    } else if (ch === '\n' || ch === undefined) {
+      row.push(field);
+      field = '';
+      if (row.some((f) => f !== '')) {
+        rows.push(row);
+      }
+      row = [];
+    } else {
+      field += ch;
+    }
+  }
+
+  return rows;
+}
+
 function escapeCsvValue(value) {
   const stringValue = String(value);
   if (
@@ -21,4 +60,4 @@ function toCsv(headers, rows) {
   return csvLines.join('\n');
 }
 
-module.exports = { toCsv };
+module.exports = { parseCsv, toCsv };

--- a/src/views/firearms/import-content.ejs
+++ b/src/views/firearms/import-content.ejs
@@ -1,0 +1,124 @@
+  <section class="app-hero">
+    <p class="label-caps">Collection</p>
+    <h2 class="page-title">Import Firearms</h2>
+    <p class="page-subtitle meta">Upload a CSV file to bulk-import firearm records.</p>
+  </section>
+
+  <section class="card import-card">
+    <h3 class="card-title">Upload CSV</h3>
+    <p class="meta import-instructions">
+      Download the <a href="/firearms/import/template" class="link">CSV template</a> to see the required column format.
+      Only <strong>Make</strong> and <strong>Model</strong> are required; all other fields are optional.
+    </p>
+
+    <div class="upload-area" id="upload-area">
+      <input type="file" id="csv-file" accept=".csv,text/csv" class="upload-input">
+      <label for="csv-file" class="upload-label">
+        <span class="upload-icon">&#8679;</span>
+        <span id="upload-text">Choose a CSV file or drag and drop</span>
+      </label>
+    </div>
+
+    <div class="form-actions">
+      <a class="btn btn-secondary" href="/firearms">Cancel</a>
+      <button class="btn" id="import-btn" disabled>Import</button>
+    </div>
+  </section>
+
+  <section class="card import-card" id="results-card" hidden>
+    <h3 class="card-title">Import Results</h3>
+    <p id="results-summary" class="import-summary"></p>
+    <ul id="results-errors" class="import-errors" hidden></ul>
+    <div class="form-actions">
+      <a class="btn btn-secondary" href="/firearms/import">Import Another</a>
+      <a class="btn btn-primary" href="/firearms">View Inventory</a>
+    </div>
+  </section>
+
+  <script>
+    (function () {
+      var fileInput = document.getElementById('csv-file');
+      var uploadArea = document.getElementById('upload-area');
+      var uploadText = document.getElementById('upload-text');
+      var importBtn = document.getElementById('import-btn');
+      var resultsCard = document.getElementById('results-card');
+      var resultsSummary = document.getElementById('results-summary');
+      var resultsErrors = document.getElementById('results-errors');
+      var csrfToken = document.getElementById('csrf-token').value;
+
+      fileInput.addEventListener('change', function () {
+        if (this.files.length > 0) {
+          uploadText.textContent = this.files[0].name;
+          uploadArea.classList.add('upload-area--selected');
+          importBtn.disabled = false;
+        } else {
+          uploadText.textContent = 'Choose a CSV file or drag and drop';
+          uploadArea.classList.remove('upload-area--selected');
+          importBtn.disabled = true;
+        }
+      });
+
+      uploadArea.addEventListener('dragover', function (e) { e.preventDefault(); uploadArea.classList.add('upload-area--drag'); });
+      uploadArea.addEventListener('dragenter', function (e) { e.preventDefault(); uploadArea.classList.add('upload-area--drag'); });
+      uploadArea.addEventListener('dragleave', function () { uploadArea.classList.remove('upload-area--drag'); });
+      uploadArea.addEventListener('drop', function (e) {
+        e.preventDefault();
+        uploadArea.classList.remove('upload-area--drag');
+        if (e.dataTransfer.files.length > 0) {
+          var dt = new DataTransfer();
+          dt.items.add(e.dataTransfer.files[0]);
+          fileInput.files = dt.files;
+          fileInput.dispatchEvent(new Event('change'));
+        }
+      });
+
+      importBtn.addEventListener('click', function () {
+        var file = fileInput.files[0];
+        if (!file) return;
+
+        importBtn.disabled = true;
+        importBtn.textContent = 'Importing…';
+
+        var reader = new FileReader();
+        reader.onload = function (e) {
+          fetch('/firearms/import', {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/plain', 'x-csrf-token': csrfToken },
+            body: e.target.result
+          })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+              if (data.error) {
+                resultsSummary.textContent = data.error;
+                resultsErrors.hidden = true;
+              } else {
+                var plural = data.imported === 1 ? 'record' : 'records';
+                resultsSummary.textContent = data.imported + ' ' + plural + ' imported successfully' +
+                  (data.failed > 0 ? ', ' + data.failed + ' skipped due to errors.' : '.');
+
+                if (data.errors && data.errors.length > 0) {
+                  resultsErrors.innerHTML = data.errors.map(function (e) {
+                    return '<li>Row ' + e.row + ': ' + e.errors + '</li>';
+                  }).join('');
+                  resultsErrors.hidden = false;
+                } else {
+                  resultsErrors.hidden = true;
+                }
+              }
+              resultsCard.hidden = false;
+              resultsCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            })
+            .catch(function () {
+              resultsSummary.textContent = 'An unexpected error occurred. Please try again.';
+              resultsErrors.hidden = true;
+              resultsCard.hidden = false;
+            })
+            .finally(function () {
+              importBtn.disabled = false;
+              importBtn.textContent = 'Import';
+            });
+        };
+        reader.readAsText(file);
+      });
+    }());
+  </script>

--- a/src/views/firearms/import.ejs
+++ b/src/views/firearms/import.ejs
@@ -1,0 +1,4 @@
+<%
+  const content = include('./import-content', locals);
+%>
+<%- include('../partials/layout', { ...locals, body: content, pageTitle: 'Import Firearms' }) %>

--- a/src/views/firearms/index-content.ejs
+++ b/src/views/firearms/index-content.ejs
@@ -11,6 +11,7 @@
       <small class="meta"><%= pagination.totalCount %> item<%= pagination.totalCount === 1 ? '' : 's' %> on record</small>
     </div>
     <div class="action-bar-actions">
+      <a class="btn btn-secondary" href="/firearms/import">Import CSV</a>
       <a class="btn btn-secondary" href="/firearms/export" download="firearms.csv">Export CSV</a>
       <a class="btn btn-primary" href="/firearms/new">+ Add Firearm</a>
     </div>

--- a/tests/unit/csv.test.js
+++ b/tests/unit/csv.test.js
@@ -1,0 +1,53 @@
+const { parseCsv } = require('../../src/shared/utils/csv');
+
+describe('parseCsv', () => {
+  test('parses a simple CSV with header and one row', () => {
+    const text = 'Make,Model,Serial\nGlock,19,ABC123';
+    expect(parseCsv(text)).toEqual([
+      ['Make', 'Model', 'Serial'],
+      ['Glock', '19', 'ABC123']
+    ]);
+  });
+
+  test('handles quoted fields containing commas', () => {
+    const text = 'Make,Notes\nGlock,"Bought at, local shop"';
+    expect(parseCsv(text)).toEqual([
+      ['Make', 'Notes'],
+      ['Glock', 'Bought at, local shop']
+    ]);
+  });
+
+  test('handles escaped double quotes inside quoted fields', () => {
+    const text = 'Make,Notes\nGlock,"Has ""great"" trigger"';
+    expect(parseCsv(text)).toEqual([
+      ['Make', 'Notes'],
+      ['Glock', 'Has "great" trigger']
+    ]);
+  });
+
+  test('handles Windows-style CRLF line endings', () => {
+    const text = 'Make,Model\r\nGlock,19\r\nSig,P320';
+    expect(parseCsv(text)).toEqual([
+      ['Make', 'Model'],
+      ['Glock', '19'],
+      ['Sig', 'P320']
+    ]);
+  });
+
+  test('skips blank lines', () => {
+    const text = 'Make,Model\nGlock,19\n\nSig,P320';
+    expect(parseCsv(text)).toEqual([
+      ['Make', 'Model'],
+      ['Glock', '19'],
+      ['Sig', 'P320']
+    ]);
+  });
+
+  test('returns empty array for empty string', () => {
+    expect(parseCsv('')).toEqual([]);
+  });
+
+  test('returns only headers row when no data rows present', () => {
+    expect(parseCsv('Make,Model\n')).toEqual([['Make', 'Model']]);
+  });
+});

--- a/tests/unit/firearms.import.test.js
+++ b/tests/unit/firearms.import.test.js
@@ -1,0 +1,134 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createDbClient } = require('../../src/infra/db/client');
+const { migrate } = require('../../src/infra/db/migrate');
+const { createFirearmsRepository } = require('../../src/infra/db/repositories/firearms.repository');
+const { createFirearmsService } = require('../../src/features/firearms/firearms.service');
+
+describe('firearmsService.importFromCsv', () => {
+  let db;
+  let dbPath;
+  let service;
+
+  beforeEach(() => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-import-'));
+    dbPath = path.join(tempDir, 'app.db');
+    db = createDbClient(dbPath);
+    migrate(db);
+    const repo = createFirearmsRepository(db);
+    service = createFirearmsService(repo);
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  test('imports valid rows and returns correct counts', () => {
+    const csv = [
+      'Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes',
+      'Glock,19,ABC123,9mm,2023-01-15,500,New,Safe,Active,,,,,Pistol,Yes,First handgun',
+      'Remington,870,XYZ789,12ga,2022-06-10,850,Used,Cabinet,Active,,,,,Shotgun,No,'
+    ].join('\n');
+
+    const result = service.importFromCsv(csv);
+
+    expect(result.imported).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.errors).toEqual([]);
+
+    const all = db.prepare('SELECT * FROM firearms ORDER BY id').all();
+    expect(all).toHaveLength(2);
+    expect(all[0].make).toBe('Glock');
+    expect(all[0].model).toBe('19');
+    expect(all[0].purchase_price).toBe(500);
+    expect(all[0].gun_warranty).toBe(1);
+    expect(all[1].make).toBe('Remington');
+    expect(all[1].gun_warranty).toBe(0);
+  });
+
+  test('skips rows missing required Make field and reports error', () => {
+    const csv = [
+      'Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes',
+      ',19,,,,,,,,,,,,,,'
+    ].join('\n');
+
+    const result = service.importFromCsv(csv);
+
+    expect(result.imported).toBe(0);
+    expect(result.failed).toBe(1);
+    expect(result.errors[0].row).toBe(2);
+    expect(result.errors[0].errors).toMatch(/Make is required/);
+  });
+
+  test('imports valid rows and skips invalid ones', () => {
+    const csv = [
+      'Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes',
+      'Glock,19,,,,,,,,,,,,,',
+      ',BadRow,,,,,,,,,,,,,,',
+      'Sig,P320,,,,,,,,,,,,,,,'
+    ].join('\n');
+
+    const result = service.importFromCsv(csv);
+
+    expect(result.imported).toBe(2);
+    expect(result.failed).toBe(1);
+    expect(result.errors[0].row).toBe(3);
+  });
+
+  test('returns zero counts for CSV with only a header row', () => {
+    const csv = 'Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes\n';
+    const result = service.importFromCsv(csv);
+    expect(result.imported).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  test('returns zero counts for empty input', () => {
+    const result = service.importFromCsv('');
+    expect(result.imported).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  test('handles quoted fields with commas in notes', () => {
+    const csv = [
+      'Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes',
+      'Glock,19,,,,,,,,,,,,,,"Bought at, local shop"'
+    ].join('\n');
+
+    const result = service.importFromCsv(csv);
+    expect(result.imported).toBe(1);
+
+    const item = db.prepare('SELECT notes FROM firearms').get();
+    expect(item.notes).toBe('Bought at, local shop');
+  });
+
+  test('clears disposition fields when status is not a disposition status', () => {
+    const csv = [
+      'Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes',
+      'Glock,19,,,,,,,,John Doe,123 Main St,2024-01-01,Sold it,,,'
+    ].join('\n');
+
+    const result = service.importFromCsv(csv);
+    expect(result.imported).toBe(1);
+
+    const item = db.prepare('SELECT * FROM firearms').get();
+    expect(item.disposition_name).toBe('');
+    expect(item.disposition_address).toBe('');
+  });
+
+  test('preserves disposition fields when status is a disposition status', () => {
+    const csv = [
+      'Make,Model,Serial,Caliber,Purchase Date,Purchase Price,Condition,Location,Status,Disposition Name,Disposition Address,Disposition Date,Disposition Reason,Firearm Type,Gun Warranty,Notes',
+      'Glock,19,,,,,,,Sold,John Doe,123 Main St,2024-01-01,Sold to friend,Pistol,,'
+    ].join('\n');
+
+    const result = service.importFromCsv(csv);
+    expect(result.imported).toBe(1);
+
+    const item = db.prepare('SELECT * FROM firearms').get();
+    expect(item.disposition_name).toBe('John Doe');
+    expect(item.status).toBe('Sold');
+  });
+});


### PR DESCRIPTION
Closes #148

## Summary

- **Import CSV button** added to the Inventory action bar (between Export CSV and Add Firearm)
- **`GET /firearms/import`** — dedicated upload page with drag-and-drop file picker and inline results
- **`GET /firearms/import/template`** — downloads a blank CSV template with all column headers matching the existing export format
- **`POST /firearms/import`** — accepts the CSV as `text/plain`, validates each row with the existing `sanitizeFirearmInput` / `validateFirearmInput` helpers, inserts valid rows, returns JSON `{ imported, failed, errors }` rendered inline without a page reload
- **No new runtime dependencies** — file reading is done client-side with FileReader; `express.text()` (built into Express) handles the body; a `parseCsv()` utility was added to `src/shared/utils/csv.js`

## Behaviour

- Only **Make** and **Model** are required; all other fields are optional
- Rows failing validation are skipped; valid rows are still imported
- After submit, results show inline: count imported, count skipped, and per-row error details
- Disposition fields (Name, Address, Date, Reason) are only persisted when Status is a disposition status (sold / lost / lost/stolen / stolen), matching existing single-record behaviour

## Test plan

- [ ] Run `npm test` — all 79 tests pass (15 new: 7 for `parseCsv`, 8 for `importFromCsv`)
- [ ] Download the template from `/firearms/import/template` — verify it has the correct header row
- [ ] Import the template (header-only) — should report 0 imported, 0 failed
- [ ] Import a CSV with valid rows — verify records appear in Inventory
- [ ] Import a CSV with a row missing Make — verify it is skipped and the error row number is shown
- [ ] Drag and drop a CSV onto the upload area — verify it works
- [ ] Import a CSV exported from the app itself — verify round-trip fidelity

https://claude.ai/code/session_01NzRA8t2gr9Tx34wLPJj2GU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzRA8t2gr9Tx34wLPJj2GU)_