### PR TITLE
feat(firearms): add In Transit status

### DIFF
--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -23,6 +23,8 @@
   --status-repair-text: #f87171;
   --status-lost-bg: #1e1a2a;
   --status-lost-text: #a78bfa;
+  --status-transit-bg: #1a2535;
+  --status-transit-text: #60a5fa;
   --border: #2a2a35;
   --border-subtle: #252530;
   --border-focus: #6ee7b7;
@@ -63,6 +65,8 @@
   --status-repair-text: #991b1b;
   --status-lost-bg: #ede9fe;
   --status-lost-text: #5b21b6;
+  --status-transit-bg: #dbeafe;
+  --status-transit-text: #1d4ed8;
   --border: #e2e0da;
   --border-subtle: #ebe9e3;
   --border-focus: #059669;
@@ -483,6 +487,11 @@ h3 {
 .badge-lost {
   background: var(--status-lost-bg);
   color: var(--status-lost-text);
+}
+
+.badge-transit {
+  background: var(--status-transit-bg);
+  color: var(--status-transit-text);
 }
 
 .flex-between {

--- a/src/views/firearms/_form.ejs
+++ b/src/views/firearms/_form.ejs
@@ -62,6 +62,7 @@
     <select name="status">
       <option value="">Select...</option>
       <option value="Active" <%= (item.status === 'Active') ? 'selected' : '' %>>Active</option>
+      <option value="In Transit" <%= (item.status === 'In Transit') ? 'selected' : '' %>>In Transit</option>
       <option value="Sold" <%= (item.status === 'Sold') ? 'selected' : '' %>>Sold</option>
       <option value="Lost/Stolen" <%= (item.status === 'Lost/Stolen') ? 'selected' : '' %>>Lost/Stolen</option>
       <option value="Under Repair" <%= (item.status === 'Under Repair') ? 'selected' : '' %>>Under Repair</option>

--- a/src/views/firearms/index-content.ejs
+++ b/src/views/firearms/index-content.ejs
@@ -20,6 +20,7 @@
     <% function getStatusBadgeClass(value) {
       const normalized = String(value || '').trim().toLowerCase();
       if (normalized === 'active') return 'badge-active';
+      if (normalized === 'in transit') return 'badge-transit';
       if (normalized === 'sold') return 'badge-sold';
       if (normalized === 'under repair' || normalized === 'repair' || normalized === 'maintenance') return 'badge-repair';
       if (normalized === 'lost' || normalized === 'lost/stolen' || normalized === 'stolen') return 'badge-lost';

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -5,6 +5,7 @@
       <% function getStatusBadgeClass(value) {
         const normalized = String(value || '').trim().toLowerCase();
         if (normalized === 'active') return 'badge-active';
+        if (normalized === 'in transit') return 'badge-transit';
         if (normalized === 'sold') return 'badge-sold';
         if (normalized === 'under repair' || normalized === 'repair' || normalized === 'maintenance') return 'badge-repair';
         if (normalized === 'lost' || normalized === 'lost/stolen' || normalized === 'stolen') return 'badge-lost';


### PR DESCRIPTION
## Summary

- Adds **In Transit** as a selectable status in the add/edit firearm form (positioned between Active and Sold)
- Renders with a distinct **blue badge** (`badge-transit`) in the inventory table and detail view
- CSS variables added for both dark and light themes (`--status-transit-bg` / `--status-transit-text`)
- Not treated as a disposition status — no transfer details section is shown when selected

## Test plan

- [ ] Run `npm test` — all 64 tests pass
- [ ] Add/edit a firearm and select **In Transit** from the status dropdown
- [ ] Verify it saves correctly and shows a blue badge on the detail page and inventory table
- [ ] Verify the inventory status filter chip appears for In Transit records
- [ ] Switch between dark and light themes and confirm the badge color is readable in both

https://claude.ai/code/session_01NzRA8t2gr9Tx34wLPJj2GU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzRA8t2gr9Tx34wLPJj2GU)_