### PR TITLE
feat(version): opt-in update check indicator with profile toggle (#173)

### DIFF
--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -8,6 +8,8 @@ const cookieParser = require('cookie-parser');
 const { doubleCsrf } = require('csrf-csrf');
 
 const { getConfig } = require('../infra/config');
+const { createVersionService } = require('../services/version.service');
+const { version } = require('../../package.json');
 const { createDbClient } = require('../infra/db/client');
 const { migrate } = require('../infra/db/migrate');
 const { createFirearmsRepository } = require('../infra/db/repositories/firearms.repository');
@@ -36,6 +38,9 @@ async function createApp(options = {}) {
   const authService = createAuthService({ adminUser: config.adminUser, settingsRepository });
 
   await authService.initializePasswordHash(config.adminPass);
+
+  const versionService = createVersionService({ currentVersion: version, enabled: config.updateCheck });
+  if (config.updateCheck) versionService.getVersionInfo().catch(() => {});
 
   const authController = createAuthController(authService);
   const firearmsService = createFirearmsService(firearmsRepository);
@@ -107,11 +112,20 @@ async function createApp(options = {}) {
   app.use('/', express.static(path.join(__dirname, '..', 'public')));
   app.use('/static', express.static(path.join(__dirname, '..', 'public')));
 
-  app.use((req, res, next) => {
+  app.use(async (req, res, next) => {
     res.locals.user = req.session.user || null;
     res.locals.currentPath = req.path;
     res.locals.csrfToken = generateCsrfToken(req, res);
     res.locals.theme = authService.getTheme();
+    res.locals.updateCheckAllowed = config.updateCheck;
+    res.locals.updateCheckEnabled = authService.getUpdateCheckEnabled();
+    try {
+      res.locals.versionInfo = config.updateCheck
+        ? await versionService.getVersionInfo()
+        : { currentVersion: version, latestVersion: null, updateAvailable: false };
+    } catch {
+      res.locals.versionInfo = { currentVersion: version, latestVersion: null, updateAvailable: false };
+    }
     next();
   });
 

--- a/src/features/auth/auth.controller.js
+++ b/src/features/auth/auth.controller.js
@@ -9,6 +9,7 @@ function createAuthController(authService) {
       preferencesSuccess: null,
       usernameValue: authService.getUsername(),
       themeValue: authService.getTheme(),
+      updateCheckEnabled: authService.getUpdateCheckEnabled(),
       ...overrides
     };
   }
@@ -107,10 +108,13 @@ function createAuthController(authService) {
     },
 
     updatePreferences(req, res) {
-      const { theme } = req.body;
+      const { theme, update_check_enabled } = req.body;
 
       try {
         authService.setTheme(theme);
+        if (res.locals.updateCheckAllowed) {
+          authService.setUpdateCheckEnabled(update_check_enabled === '1');
+        }
       } catch (error) {
         return res.status(400).render('auth/profile', createProfileViewModel({ preferencesError: error.message }));
       }

--- a/src/features/auth/auth.service.js
+++ b/src/features/auth/auth.service.js
@@ -78,6 +78,14 @@ function createAuthService({ adminUser, settingsRepository }) {
         throw new Error('Invalid theme value');
       }
       settingsRepository.set('theme', theme);
+    },
+
+    getUpdateCheckEnabled() {
+      return settingsRepository.get('update_check_enabled') === '1';
+    },
+
+    setUpdateCheckEnabled(enabled) {
+      settingsRepository.set('update_check_enabled', enabled ? '1' : '0');
     }
   };
 }

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -19,7 +19,8 @@ function getConfig() {
     adminPass: process.env.ADMIN_PASSWORD || 'changeme',
     databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db'),
     trustProxy,
-    secureCookies
+    secureCookies,
+    updateCheck: process.env.UPDATE_CHECK === 'true'
   };
 }
 

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1451,6 +1451,59 @@ h3 {
   }
 }
 
+/* Footer */
+.app-footer {
+  border-top: 1px solid var(--border);
+  padding: 0.75rem 0;
+  margin-top: 2rem;
+}
+
+.footer-inner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.footer-version {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-family: var(--font-mono);
+}
+
+.footer-update-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  background: var(--accent);
+  color: var(--bg);
+  text-decoration: none;
+}
+
+.footer-update-badge:hover {
+  opacity: 0.85;
+}
+
+/* Toggle row for checkbox + label text */
+.toggle-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  cursor: pointer;
+}
+
+.toggle-label-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-weight: 500;
+}
+
+.toggle-label-text .helper-text {
+  font-weight: 400;
+}
+
 @media (max-width: 640px) {
   .settings-grid {
     grid-template-columns: 1fr;

--- a/src/services/version.service.js
+++ b/src/services/version.service.js
@@ -1,0 +1,57 @@
+const https = require('https');
+
+const RELEASES_URL = 'https://api.github.com/repos/Gogorichielab/PPCollection/releases/latest';
+const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+function createVersionService({ currentVersion, enabled }) {
+  let cache = null;
+  let lastChecked = null;
+
+  function fetchLatestVersion() {
+    return new Promise((resolve) => {
+      const options = {
+        headers: {
+          'User-Agent': `PPCollection/${currentVersion}`,
+          Accept: 'application/vnd.github+json'
+        }
+      };
+      https
+        .get(RELEASES_URL, options, (res) => {
+          if (res.statusCode !== 200) return resolve(null);
+          let data = '';
+          res.on('data', (chunk) => {
+            data += chunk;
+          });
+          res.on('end', () => {
+            try {
+              const json = JSON.parse(data);
+              resolve(json.tag_name ? json.tag_name.replace(/^v/, '') : null);
+            } catch {
+              resolve(null);
+            }
+          });
+        })
+        .on('error', () => resolve(null));
+    });
+  }
+
+  async function getVersionInfo() {
+    if (!enabled) {
+      return { currentVersion, latestVersion: null, updateAvailable: false };
+    }
+    const now = Date.now();
+    if (!cache || !lastChecked || now - lastChecked > CACHE_TTL_MS) {
+      cache = await fetchLatestVersion();
+      lastChecked = now;
+    }
+    return {
+      currentVersion,
+      latestVersion: cache,
+      updateAvailable: !!cache && cache !== currentVersion
+    };
+  }
+
+  return { getVersionInfo };
+}
+
+module.exports = { createVersionService };

--- a/src/views/auth/profile-content.ejs
+++ b/src/views/auth/profile-content.ejs
@@ -49,6 +49,15 @@
           <option value="light" <%= themeValue === 'light' ? 'selected' : '' %>>Light</option>
         </select>
       </label>
+      <% if (updateCheckAllowed) { %>
+        <label class="toggle-row">
+          <span class="toggle-label-text">
+            Check for updates every 2 weeks
+            <span class="helper-text">Requires outbound access to api.github.com</span>
+          </span>
+          <input type="checkbox" name="update_check_enabled" value="1" <%= updateCheckEnabled ? 'checked' : '' %>>
+        </label>
+      <% } %>
       <div class="form-actions settings-form-actions">
         <button class="btn" type="submit">Save</button>
       </div>

--- a/src/views/partials/layout.ejs
+++ b/src/views/partials/layout.ejs
@@ -83,6 +83,18 @@
   <main class="container">
     <%- body %>
   </main>
+  <footer class="app-footer">
+    <div class="container footer-inner">
+      <span class="footer-version">PPCollection v<%= versionInfo.currentVersion %></span>
+      <% if (updateCheckAllowed && updateCheckEnabled && versionInfo.updateAvailable) { %>
+        <a class="footer-update-badge"
+           href="https://github.com/Gogorichielab/PPCollection/releases/latest"
+           target="_blank" rel="noopener noreferrer">
+          v<%= versionInfo.latestVersion %> available — view release
+        </a>
+      <% } %>
+    </div>
+  </footer>
   <script src="/static/js/theme.js"></script>
   <% if (typeof pageScript !== 'undefined' && pageScript) { %>
   <script src="<%= pageScript %>"></script>

--- a/tests/unit/version.service.test.js
+++ b/tests/unit/version.service.test.js
@@ -6,7 +6,7 @@ const { createVersionService } = require('../../src/services/version.service');
 jest.mock('https');
 
 function mockHttpsGet(statusCode, body) {
-  https.get.mockImplementation((url, options, callback) => {
+  https.get.mockImplementation((_url, _options, callback) => {
     const res = {
       statusCode,
       on: jest.fn((event, handler) => {
@@ -49,7 +49,7 @@ test('returns no update info and does not fetch when disabled', async () => {
 });
 
 test('resolves silently on network failure', async () => {
-  https.get.mockImplementation((url, options, callback) => {
+  https.get.mockImplementation((_url, _options, _callback) => {
     const req = { on: jest.fn((event, handler) => { if (event === 'error') handler(new Error('ECONNREFUSED')); }) };
     return req;
   });

--- a/tests/unit/version.service.test.js
+++ b/tests/unit/version.service.test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const https = require('https');
+const { createVersionService } = require('../../src/services/version.service');
+
+jest.mock('https');
+
+function mockHttpsGet(statusCode, body) {
+  https.get.mockImplementation((url, options, callback) => {
+    const res = {
+      statusCode,
+      on: jest.fn((event, handler) => {
+        if (event === 'data') handler(typeof body === 'string' ? body : JSON.stringify(body));
+        if (event === 'end') handler();
+      })
+    };
+    callback(res);
+    return { on: jest.fn() };
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('update available when latest tag differs from current version', async () => {
+  mockHttpsGet(200, { tag_name: 'v2.0.0' });
+  const service = createVersionService({ currentVersion: '1.0.0', enabled: true });
+  const info = await service.getVersionInfo();
+  expect(info.updateAvailable).toBe(true);
+  expect(info.latestVersion).toBe('2.0.0');
+  expect(info.currentVersion).toBe('1.0.0');
+});
+
+test('up to date when latest tag matches current version', async () => {
+  mockHttpsGet(200, { tag_name: 'v1.0.0' });
+  const service = createVersionService({ currentVersion: '1.0.0', enabled: true });
+  const info = await service.getVersionInfo();
+  expect(info.updateAvailable).toBe(false);
+  expect(info.latestVersion).toBe('1.0.0');
+});
+
+test('returns no update info and does not fetch when disabled', async () => {
+  const service = createVersionService({ currentVersion: '1.0.0', enabled: false });
+  const info = await service.getVersionInfo();
+  expect(info.updateAvailable).toBe(false);
+  expect(info.latestVersion).toBeNull();
+  expect(https.get).not.toHaveBeenCalled();
+});
+
+test('resolves silently on network failure', async () => {
+  https.get.mockImplementation((url, options, callback) => {
+    const req = { on: jest.fn((event, handler) => { if (event === 'error') handler(new Error('ECONNREFUSED')); }) };
+    return req;
+  });
+  const service = createVersionService({ currentVersion: '1.0.0', enabled: true });
+  const info = await service.getVersionInfo();
+  expect(info.updateAvailable).toBe(false);
+  expect(info.latestVersion).toBeNull();
+});
+
+test('reuses cache within TTL and only fetches once', async () => {
+  mockHttpsGet(200, { tag_name: 'v2.0.0' });
+  const service = createVersionService({ currentVersion: '1.0.0', enabled: true });
+  await service.getVersionInfo();
+  await service.getVersionInfo();
+  expect(https.get).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a `UPDATE_CHECK=true` env var as a server-admin master gate for the feature (safe for air-gapped installs by default)
- When enabled, a **Check for updates every 2 weeks** toggle appears in Profile → Display preferences
- When both the server gate and user toggle are on, the footer shows a badge linking to the latest GitHub release if a newer version is available
- Version info is fetched from `api.github.com/repos/Gogorichielab/PPCollection/releases/latest`, cached for 14 days, and fails silently on network errors — preserving the offline-first design

## Changes

| File | Change |
|------|--------|
| `src/infra/config/index.js` | Added `updateCheck` flag from `UPDATE_CHECK` env var |
| `src/services/version.service.js` | New service: GitHub API fetch + 14-day in-memory cache |
| `src/features/auth/auth.service.js` | Added `getUpdateCheckEnabled()` / `setUpdateCheckEnabled()` |
| `src/app/createApp.js` | Import version service, async middleware, cache warm on startup |
| `src/features/auth/auth.controller.js` | `updateCheckEnabled` in viewmodel; handle toggle in `updatePreferences()` |
| `src/views/auth/profile-content.ejs` | Checkbox toggle (shown only when `updateCheckAllowed`) |
| `src/views/partials/layout.ejs` | Footer with version + conditional update badge |
| `src/public/css/styles.css` | `.app-footer`, `.footer-inner`, `.footer-version`, `.footer-update-badge`, `.toggle-row` |
| `tests/unit/version.service.test.js` | 5 tests: update available, up-to-date, disabled, network failure, cache reuse |

## Test plan

- [ ] `npm test` — all 69 tests pass (5 new version service tests)
- [ ] Without `UPDATE_CHECK=true`: footer shows only current version; no toggle in profile
- [ ] With `UPDATE_CHECK=true`, toggle off: footer shows current version only
- [ ] With `UPDATE_CHECK=true`, toggle on, newer version mocked: update badge appears in footer
- [ ] With `UPDATE_CHECK=true`, network unavailable: no error, footer shows current version only

Closes #173

https://claude.ai/code/session_01NzRA8t2gr9Tx34wLPJj2GU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NzRA8t2gr9Tx34wLPJj2GU)_