### PR TITLE
test(version): fix eslint unused args in https mock

### DIFF
--- a/tests/unit/version.service.test.js
+++ b/tests/unit/version.service.test.js
@@ -6,7 +6,7 @@ const { createVersionService } = require('../../src/services/version.service');
 jest.mock('https');
 
 function mockHttpsGet(statusCode, body) {
-  https.get.mockImplementation((url, options, callback) => {
+  https.get.mockImplementation((_url, _options, callback) => {
     const res = {
       statusCode,
       on: jest.fn((event, handler) => {
@@ -49,7 +49,7 @@ test('returns no update info and does not fetch when disabled', async () => {
 });
 
 test('resolves silently on network failure', async () => {
-  https.get.mockImplementation((url, options, callback) => {
+  https.get.mockImplementation((_url, _options, _callback) => {
     const req = { on: jest.fn((event, handler) => { if (event === 'error') handler(new Error('ECONNREFUSED')); }) };
     return req;
   });


### PR DESCRIPTION
### Motivation
- Linting failed due to unused parameters in the `https.get` mocks within the version service unit tests, which violated the repo's `no-unused-vars` rule for function arguments.

### Description
- Updated `tests/unit/version.service.test.js` to rename intentionally unused `https.get` mock parameters to `_url`, `_options`, and `_callback` so they are recognized as intentionally unused by ESLint.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm test` and all test suites passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed5fb5a1d48332b385d449884b4888)