### PR TITLE
security: rate-limit auth + tighten body / validator / fetch limits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "csrf-csrf": "^4.0.3",
         "ejs": "^5.0.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.4.1",
         "express-session": "^1.19.0",
         "helmet": "^8.1.0",
         "method-override": "^3.0.0",
@@ -4673,6 +4674,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express-session": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
@@ -5670,6 +5689,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "csrf-csrf": "^4.0.3",
     "ejs": "^5.0.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.4.1",
     "express-session": "^1.19.0",
     "helmet": "^8.1.0",
     "method-override": "^3.0.0",

--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -62,8 +62,8 @@ async function createApp(options = {}) {
 
   app.use(helmet());
   app.use(cookieParser());
-  app.use(express.json());
-  app.use(express.urlencoded({ extended: true }));
+  app.use(express.json({ limit: '50kb' }));
+  app.use(express.urlencoded({ extended: true, limit: '50kb', parameterLimit: 100 }));
   app.use(methodOverride('_method'));
   app.use(morgan('dev'));
   app.use(

--- a/src/features/auth/auth.routes.js
+++ b/src/features/auth/auth.routes.js
@@ -1,19 +1,41 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const { requireAuth } = require('../../app/middleware/auth');
 
 function createAuthRoutes(authController) {
+  // Limiters are created per-app so each createApp() call gets its own in-memory
+  // store. Login limiter only counts failed attempts (skipSuccessfulRequests),
+  // since successful logins return 302. Password change limiter counts every
+  // attempt since failed re-renders return 200 OK with an inline error.
+  const loginLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skipSuccessfulRequests: true,
+    message: 'Too many login attempts. Please try again in 15 minutes.'
+  });
+
+  const passwordChangeLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 20,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: 'Too many password change attempts. Please try again in 15 minutes.'
+  });
+
   const router = express.Router();
 
   router.get('/login', authController.showLogin);
-  router.post('/login', authController.login);
+  router.post('/login', loginLimiter, authController.login);
   router.post('/logout', authController.logout);
 
   router.get('/change-password', requireAuth, authController.showChangePassword);
-  router.post('/change-password', requireAuth, authController.changePassword);
+  router.post('/change-password', requireAuth, passwordChangeLimiter, authController.changePassword);
 
   router.get('/profile', requireAuth, authController.showProfile);
   router.post('/profile/username', requireAuth, authController.updateUsername);
-  router.post('/profile/password', requireAuth, authController.updatePassword);
+  router.post('/profile/password', requireAuth, passwordChangeLimiter, authController.updatePassword);
   router.post('/profile/preferences', requireAuth, authController.updatePreferences);
 
   router.post('/toggle-theme', requireAuth, authController.toggleTheme);

--- a/src/features/firearms/firearms.validators.js
+++ b/src/features/firearms/firearms.validators.js
@@ -1,5 +1,24 @@
 const DISPOSITION_STATUSES = new Set(['sold', 'lost/stolen', 'lost', 'stolen']);
 
+const FIELD_LIMITS = {
+  make: 100,
+  model: 100,
+  serial: 64,
+  caliber: 50,
+  firearm_type: 50,
+  condition: 50,
+  location: 100,
+  status: 50,
+  purchase_date: 32,
+  disposition_name: 100,
+  disposition_address: 200,
+  disposition_date: 32,
+  disposition_reason: 500,
+  notes: 4000
+};
+
+const MAX_PURCHASE_PRICE = 1_000_000;
+
 function isDispositionStatus(status) {
   return DISPOSITION_STATUSES.has(String(status || '').trim().toLowerCase());
 }
@@ -38,8 +57,21 @@ function validateFirearmInput(data) {
     fieldErrors.model = 'Model is required.';
   }
 
-  if (data.purchase_price !== null && data.purchase_price < 0) {
-    fieldErrors.purchase_price = 'Purchase price cannot be negative.';
+  for (const [field, maxLength] of Object.entries(FIELD_LIMITS)) {
+    const value = data[field];
+    if (typeof value === 'string' && value.length > maxLength) {
+      fieldErrors[field] = fieldErrors[field] || `${humanizeField(field)} must be ${maxLength} characters or fewer.`;
+    }
+  }
+
+  if (data.purchase_price !== null) {
+    if (Number.isNaN(data.purchase_price)) {
+      fieldErrors.purchase_price = 'Purchase price must be a number.';
+    } else if (data.purchase_price < 0) {
+      fieldErrors.purchase_price = 'Purchase price cannot be negative.';
+    } else if (data.purchase_price > MAX_PURCHASE_PRICE) {
+      fieldErrors.purchase_price = `Purchase price must be ${MAX_PURCHASE_PRICE.toLocaleString()} or less.`;
+    }
   }
 
   return {
@@ -48,4 +80,17 @@ function validateFirearmInput(data) {
   };
 }
 
-module.exports = { sanitizeFirearmInput, validateFirearmInput, isDispositionStatus };
+function humanizeField(field) {
+  return field
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+module.exports = {
+  sanitizeFirearmInput,
+  validateFirearmInput,
+  isDispositionStatus,
+  FIELD_LIMITS,
+  MAX_PURCHASE_PRICE
+};

--- a/src/services/version.service.js
+++ b/src/services/version.service.js
@@ -2,6 +2,7 @@ const https = require('https');
 
 const RELEASES_URL = 'https://api.github.com/repos/Gogorichielab/PPCollection/releases/latest';
 const CACHE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 5_000;
 
 function createVersionService({ currentVersion, enabled }) {
   let cache = null;
@@ -16,27 +17,32 @@ function createVersionService({ currentVersion, enabled }) {
           Accept: 'application/vnd.github+json'
         }
       };
-      https
-        .get(RELEASES_URL, options, (res) => {
-          if (res.statusCode !== 200) {
-            res.resume();
-            return resolve(null);
+      const req = https.get(RELEASES_URL, options, (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          return resolve(null);
+        }
+        let data = '';
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          try {
+            const json = JSON.parse(data);
+            resolve(json.tag_name ? json.tag_name.replace(/^v/, '') : null);
+          } catch {
+            resolve(null);
           }
-          let data = '';
-          res.on('data', (chunk) => {
-            data += chunk;
-          });
-          res.on('end', () => {
-            try {
-              const json = JSON.parse(data);
-              resolve(json.tag_name ? json.tag_name.replace(/^v/, '') : null);
-            } catch {
-              resolve(null);
-            }
-          });
-          res.on('error', () => resolve(null));
-        })
-        .on('error', () => resolve(null));
+        });
+        res.on('error', () => resolve(null));
+      });
+      // Abort the request if GitHub is slow or unreachable so that we never
+      // block startup or per-request rendering on a stalled socket.
+      req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+        req.destroy();
+        resolve(null);
+      });
+      req.on('error', () => resolve(null));
     });
   }
 

--- a/tests/unit/firearms.validators.test.js
+++ b/tests/unit/firearms.validators.test.js
@@ -1,4 +1,9 @@
-const { sanitizeFirearmInput, validateFirearmInput } = require('../../src/features/firearms/firearms.validators');
+const {
+  sanitizeFirearmInput,
+  validateFirearmInput,
+  FIELD_LIMITS,
+  MAX_PURCHASE_PRICE
+} = require('../../src/features/firearms/firearms.validators');
 
 describe('firearms.validators', () => {
   test('sanitizeFirearmInput trims strings and normalizes values', () => {
@@ -23,5 +28,61 @@ describe('firearms.validators', () => {
       make: 'Make is required.',
       model: 'Model is required.'
     });
+  });
+
+  test('validateFirearmInput rejects make exceeding length limit', () => {
+    const result = validateFirearmInput({
+      make: 'a'.repeat(FIELD_LIMITS.make + 1),
+      model: 'M1'
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.make).toMatch(/100 characters or fewer/);
+  });
+
+  test('validateFirearmInput rejects notes exceeding length limit', () => {
+    const result = validateFirearmInput({
+      make: 'Glock',
+      model: '19',
+      notes: 'x'.repeat(FIELD_LIMITS.notes + 1)
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.notes).toMatch(/4000 characters or fewer/);
+  });
+
+  test('validateFirearmInput rejects purchase price above maximum', () => {
+    const result = validateFirearmInput({
+      make: 'Glock',
+      model: '19',
+      purchase_price: MAX_PURCHASE_PRICE + 1
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.purchase_price).toMatch(/or less/);
+  });
+
+  test('validateFirearmInput rejects NaN purchase price', () => {
+    const result = validateFirearmInput({
+      make: 'Glock',
+      model: '19',
+      purchase_price: Number.NaN
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.purchase_price).toBe('Purchase price must be a number.');
+  });
+
+  test('validateFirearmInput accepts a fully valid record', () => {
+    const result = validateFirearmInput({
+      make: 'Glock',
+      model: '19',
+      serial: 'ABC123',
+      notes: 'normal notes',
+      purchase_price: 500
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.fieldErrors).toEqual({});
   });
 });

--- a/tests/unit/version.service.test.js
+++ b/tests/unit/version.service.test.js
@@ -9,13 +9,14 @@ function mockHttpsGet(statusCode, body) {
   https.get.mockImplementation((_url, _options, callback) => {
     const res = {
       statusCode,
+      resume: jest.fn(),
       on: jest.fn((event, handler) => {
         if (event === 'data') handler(typeof body === 'string' ? body : JSON.stringify(body));
         if (event === 'end') handler();
       })
     };
     callback(res);
-    return { on: jest.fn() };
+    return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
   });
 }
 
@@ -50,7 +51,11 @@ test('returns no update info and does not fetch when disabled', async () => {
 
 test('resolves silently on network failure', async () => {
   https.get.mockImplementation((_url, _options, _callback) => {
-    const req = { on: jest.fn((event, handler) => { if (event === 'error') handler(new Error('ECONNREFUSED')); }) };
+    const req = {
+      setTimeout: jest.fn(),
+      destroy: jest.fn(),
+      on: jest.fn((event, handler) => { if (event === 'error') handler(new Error('ECONNREFUSED')); })
+    };
     return req;
   });
   const service = createVersionService({ currentVersion: '1.0.0', enabled: true });
@@ -67,7 +72,7 @@ test('drains response body and resolves null on non-200 status', async () => {
       resume: jest.fn()
     };
     callback(capturedRes);
-    return { on: jest.fn() };
+    return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
   });
   const service = createVersionService({ currentVersion: '1.0.0', enabled: true });
   const info = await service.getVersionInfo();
@@ -87,12 +92,32 @@ test('resolves null on response stream error', async () => {
     };
     callback(res);
     setImmediate(() => handlers['error'] && handlers['error'](new Error('stream error')));
-    return { on: jest.fn() };
+    return { on: jest.fn(), setTimeout: jest.fn(), destroy: jest.fn() };
   });
   const service = createVersionService({ currentVersion: '1.0.0', enabled: true });
   const info = await service.getVersionInfo();
   expect(info.updateAvailable).toBe(false);
   expect(info.latestVersion).toBeNull();
+});
+
+test('aborts and resolves null when request times out', async () => {
+  let capturedReq;
+  https.get.mockImplementation((_url, _options, _callback) => {
+    capturedReq = {
+      setTimeout: jest.fn((_ms, handler) => {
+        setImmediate(handler);
+      }),
+      destroy: jest.fn(),
+      on: jest.fn()
+    };
+    return capturedReq;
+  });
+  const service = createVersionService({ currentVersion: '1.0.0', enabled: true });
+  const info = await service.getVersionInfo();
+  expect(info.updateAvailable).toBe(false);
+  expect(info.latestVersion).toBeNull();
+  expect(capturedReq.setTimeout).toHaveBeenCalledWith(5000, expect.any(Function));
+  expect(capturedReq.destroy).toHaveBeenCalled();
 });
 
 test('reuses cache within TTL and only fetches once', async () => {


### PR DESCRIPTION
## Summary

Implements four security findings from the audit (#340–#343) plus a Dependabot PR-grouping change. The QA tooling cleanup that was previously on this branch has been split into PR #347.

### Security audit fixes

- **#340** — `feat(auth)`: rate-limit `POST /login` (10 failed attempts / 15 min) and `POST /change-password` + `POST /profile/password` (20 attempts / 15 min). Limiters are scoped per-app so each `createApp()` gets its own in-memory store, which keeps the test suite clean.
- **#341** — `fix(version-service)`: add a 5s `req.setTimeout` to the GitHub release-check so a slow upstream can't stall the in-flight fetch. Existing fail-open behavior (`resolve(null)`) is preserved.
- **#342** — `fix(security)`: explicitly cap `express.json` and `express.urlencoded` at 50 KB, plus `parameterLimit: 100`. The CSV-import route already declares its own 2 MB text limit, so the global parsers are now equally explicit.
- **#343** — `fix(firearms)`: add per-field length limits (make/model 100, serial 64, notes 4000, etc.), a 1 M cap and NaN check on `purchase_price`, and matching unit tests.

### Dependabot

- `ci(dependabot)`: every ecosystem (npm, github-actions, docker) groups all version updates under a single wildcard group with `open-pull-requests-limit: 1` — at most three rolled-up PRs per Monday instead of ~20.

## Risk

All findings rated **low risk of breaking change** in the audit. Limits are well above any payload the current UI generates, the rate-limit thresholds tolerate normal use, and the version-service change is strictly "fail faster".

## Test plan

- [x] `npm test` — 94/94 passing (added 5 validator tests + 1 timeout test)
- [x] `npm run lint` — clean
- [ ] Manual smoke test: log in, edit a firearm, import a CSV, toggle theme
- [ ] Verify the 11th failed login in 15 minutes returns 429
- [ ] Verify form length limits surface inline errors instead of truncating silently

Closes #340, #341, #342, #343

## Related

- #347 — QA tooling cleanup pass (lint/jest/CI/CodeQL/docs), originally on this branch, split out for separate review

https://claude.ai/code/session_016wAgkh3Z8mcM1ZjGVKTKCn