### PR TITLE
fix(ci): make release version bump idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,12 @@ jobs:
 
           git checkout -B "$BRANCH"
 
-          npm version "$VERSION" --no-git-tag-version
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          if [ "$CURRENT_VERSION" != "$VERSION" ]; then
+            npm version "$VERSION" --no-git-tag-version
+          else
+            echo "package.json is already at version $VERSION; skipping npm version bump."
+          fi
 
           node --input-type=module <<'NODE'
           import fs from 'node:fs';


### PR DESCRIPTION
## Summary
- add an idempotent guard in `.github/workflows/release.yml` before running `npm version`
- compare `package.json` current version to `${VERSION}` and only bump when they differ
- log a skip message when the version is already current so the workflow continues to changelog commit logic

## Why
The release workflow could fail with `npm error Version not changed` when semantic-release computes a version that is already present in `package.json` (for example `1.20.0`). This change prevents that hard failure and allows the job to continue cleanly.

## Validation
- static review of the updated release job script in `.github/workflows/release.yml`
- ensured existing behavior is preserved when a bump is actually needed

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0d524fc8483329337e419b77d8951)