### PR TITLE
feat(security)!: refuse to start with default ADMIN_PASSWORD in production (#337)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# Pew Pew Collection — sample environment configuration
+# Copy this file to `.env` and edit values before starting the app.
+
+# ──────────────────────────────────────────────────────────────────
+# REQUIRED for first-run in production
+# ──────────────────────────────────────────────────────────────────
+
+# Admin login password used to seed the bcrypt hash on first run.
+# The app refuses to start in production if this is unset or `changeme`.
+# Generate with: openssl rand -base64 24
+ADMIN_PASSWORD=
+
+# Cryptographic key for signing session and CSRF cookies.
+# Generate with: openssl rand -hex 32
+SESSION_SECRET=
+
+# ──────────────────────────────────────────────────────────────────
+# Optional
+# ──────────────────────────────────────────────────────────────────
+
+# Admin login username (default: admin).
+# ADMIN_USERNAME=admin
+
+# HTTP port the server listens on (default: 3000).
+# PORT=3000
+
+# Path to the SQLite database file (default: /data/app.db in Docker,
+# ./data/app.db otherwise).
+# DATABASE_PATH=/data/app.db
+
+# Set to `true` when running behind an HTTPS reverse proxy (nginx,
+# Caddy, Traefik). Required for SECURE_COOKIES=true to function.
+# TRUST_PROXY=false
+
+# Set to `true` when serving the app over HTTPS. Requires
+# TRUST_PROXY=true behind a reverse proxy.
+# SECURE_COOKIES=false
+
+# Opt-in: check GitHub Releases for new app versions (cached 14 days).
+# UPDATE_CHECK=false

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Open `http://localhost:3000`. On first login you will be prompted to change the 
 |---|---|---|---|
 | `SESSION_SECRET` | Session signing secret | `ppcollection_dev_secret` | **Required in production.** Generate with `openssl rand -hex 32` |
 | `ADMIN_USERNAME` | Username for the admin account | `admin` | Used for initial login |
-| `ADMIN_PASSWORD` | Initial admin password | `changeme` | A change is forced on first login |
+| `ADMIN_PASSWORD` | Initial admin password | `changeme` | **Required in production for first-run.** A change is forced on first login. The app refuses to seed a fresh deployment with the documented default. |
 | `PORT` | HTTP port the server listens on | `3000` | Runtime server port |
 | `DATABASE_PATH` | Path to the SQLite database file | `/data/app.db` | Defaults to `/data` in Docker |
 | `TRUST_PROXY` | Trust `X-Forwarded-Proto` from a reverse proxy | `false` | Set to `true` when running behind nginx, Caddy, or Traefik |
@@ -62,6 +62,31 @@ Open `http://localhost:3000`. On first login you will be prompted to change the 
 > `SECURE_COOKIES=true` to enable full cookie security. Do not set
 > `SECURE_COOKIES=true` without a working HTTPS reverse proxy — sessions
 > will silently break.
+
+> **`ADMIN_PASSWORD` is required for first-run in production.** When
+> `NODE_ENV=production` (which is the default in the published Docker
+> image), the app refuses to start if `ADMIN_PASSWORD` is unset or
+> matches the documented default of `changeme`. Existing deployments
+> are unaffected — the env var is only used to seed the bcrypt hash on
+> first run, so once your `app.db` has been seeded the value is no
+> longer read at startup. Upgrading users will see the warning in the
+> startup log but the app will keep running.
+
+## Upgrading
+
+Existing deployments continue to work without configuration changes.
+The first-run `ADMIN_PASSWORD` guard introduced in v2.x only affects
+deployments that have **never seeded** an admin account — practically,
+that means new installations. If you've been running the app, your
+admin account hash is already stored in `app.db`, the env var is no
+longer consulted at startup, and no action is required.
+
+If you are starting fresh (no `app.db`), set `ADMIN_PASSWORD` to a
+strong value before the first start:
+
+```bash
+ADMIN_PASSWORD="$(openssl rand -base64 24)"
+```
 
 ## Screenshots
 

--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -7,7 +7,7 @@ const morgan = require('morgan');
 const cookieParser = require('cookie-parser');
 const { doubleCsrf } = require('csrf-csrf');
 
-const { getConfig } = require('../infra/config');
+const { getConfig, DEFAULT_ADMIN_PASSWORD } = require('../infra/config');
 const { createVersionService } = require('../services/version.service');
 const { version } = require('../../package.json');
 const { createDbClient } = require('../infra/db/client');
@@ -36,6 +36,21 @@ async function createApp(options = {}) {
   const settingsRepository = createSettingsRepository(db);
   const firearmsRepository = createFirearmsRepository(db);
   const authService = createAuthService({ adminUser: config.adminUser, settingsRepository });
+
+  // Guard: in production, refuse to seed the admin account with the documented
+  // default password. Only fires on first-run (no password_hash yet); existing
+  // deployments always pass through because their hash is already seeded.
+  if (
+    config.isProduction &&
+    config.adminPass === DEFAULT_ADMIN_PASSWORD &&
+    !settingsRepository.exists('password_hash')
+  ) {
+    throw new Error(
+      'Refusing to start: ADMIN_PASSWORD is unset or using the documented default. ' +
+        'Set ADMIN_PASSWORD to a strong value (e.g. `openssl rand -base64 24`) and restart. ' +
+        'See the README "Configuration" section for details.'
+    );
+  }
 
   await authService.initializePasswordHash(config.adminPass);
 

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -1,8 +1,12 @@
 const path = require('path');
 
+const DEFAULT_ADMIN_PASSWORD = 'changeme';
+
 function getConfig() {
   const trustProxy = process.env.TRUST_PROXY === 'true';
   const secureCookies = process.env.SECURE_COOKIES === 'true';
+  const isProduction = process.env.NODE_ENV === 'production';
+  const adminPass = process.env.ADMIN_PASSWORD || DEFAULT_ADMIN_PASSWORD;
 
   if (secureCookies && !trustProxy) {
     console.warn(
@@ -12,16 +16,25 @@ function getConfig() {
     );
   }
 
+  if (adminPass === DEFAULT_ADMIN_PASSWORD) {
+    console.warn(
+      '[config] WARNING: ADMIN_PASSWORD is unset or using the documented default. ' +
+        'Set ADMIN_PASSWORD to a strong value before exposing the app. ' +
+        'In production, the app will refuse to seed an admin account with this value.'
+    );
+  }
+
   return {
     port: process.env.PORT ? Number(process.env.PORT) : 3000,
     sessionSecret: process.env.SESSION_SECRET || 'ppcollection_dev_secret',
     adminUser: process.env.ADMIN_USERNAME || 'admin',
-    adminPass: process.env.ADMIN_PASSWORD || 'changeme',
+    adminPass,
     databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db'),
     trustProxy,
     secureCookies,
+    isProduction,
     updateCheck: process.env.UPDATE_CHECK === 'true'
   };
 }
 
-module.exports = { getConfig };
+module.exports = { getConfig, DEFAULT_ADMIN_PASSWORD };

--- a/tests/integration/boot-guard.integration.test.js
+++ b/tests/integration/boot-guard.integration.test.js
@@ -1,0 +1,95 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createApp } = require('../../src/app/createApp');
+const { DEFAULT_ADMIN_PASSWORD } = require('../../src/infra/config');
+const { createDbClient } = require('../../src/infra/db/client');
+const { migrate } = require('../../src/infra/db/migrate');
+const { createSettingsRepository } = require('../../src/infra/db/repositories/settings.repository');
+
+function freshDbPath() {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-bootguard-'));
+  return path.join(tempDir, 'app.db');
+}
+
+function cleanup(dbPath, app) {
+  if (app && app.locals && app.locals.db) {
+    app.locals.db.close();
+  }
+  fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+}
+
+describe('boot guard — default ADMIN_PASSWORD in production', () => {
+  test('refuses to start in production with default password and no seeded hash', async () => {
+    const dbPath = freshDbPath();
+    const config = {
+      port: 0,
+      sessionSecret: 'test-secret',
+      adminUser: 'admin',
+      adminPass: DEFAULT_ADMIN_PASSWORD,
+      databasePath: dbPath,
+      isProduction: true
+    };
+
+    await expect(createApp({ config })).rejects.toThrow(/ADMIN_PASSWORD/);
+
+    cleanup(dbPath);
+  });
+
+  test('starts in production when password_hash is already seeded, even with default password', async () => {
+    const dbPath = freshDbPath();
+    // Pre-seed a hash so this looks like an existing deployment.
+    const db = createDbClient(dbPath);
+    migrate(db);
+    const settings = createSettingsRepository(db);
+    settings.set('password_hash', '$2b$12$seededhashvaluefornullop');
+    settings.set('username', 'admin');
+    db.close();
+
+    const config = {
+      port: 0,
+      sessionSecret: 'test-secret',
+      adminUser: 'admin',
+      adminPass: DEFAULT_ADMIN_PASSWORD,
+      databasePath: dbPath,
+      isProduction: true
+    };
+
+    const app = await createApp({ config });
+    expect(app).toBeDefined();
+    cleanup(dbPath, app);
+  });
+
+  test('starts in non-production with default password and no seeded hash', async () => {
+    const dbPath = freshDbPath();
+    const config = {
+      port: 0,
+      sessionSecret: 'test-secret',
+      adminUser: 'admin',
+      adminPass: DEFAULT_ADMIN_PASSWORD,
+      databasePath: dbPath,
+      isProduction: false
+    };
+
+    const app = await createApp({ config });
+    expect(app).toBeDefined();
+    cleanup(dbPath, app);
+  });
+
+  test('starts in production with a non-default password', async () => {
+    const dbPath = freshDbPath();
+    const config = {
+      port: 0,
+      sessionSecret: 'test-secret',
+      adminUser: 'admin',
+      adminPass: 'a-real-strong-password-set-by-the-operator',
+      databasePath: dbPath,
+      isProduction: true
+    };
+
+    const app = await createApp({ config });
+    expect(app).toBeDefined();
+    cleanup(dbPath, app);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #337. Adds a boot-time guard that refuses to start in production when the documented default `ADMIN_PASSWORD=changeme` would be used to seed a fresh admin account. Until now the app silently accepted the default, leaving any unconfigured production deployment reachable with publicly-documented credentials for the brief window before the first login.

The guard fires only when **all three** are true:
1. `NODE_ENV=production`
2. `ADMIN_PASSWORD` is unset or equals `changeme`
3. The `settings` table has no `password_hash` row yet (first run)

In non-production a `[config] WARNING:` is logged but the app still boots, so the local dev loop is unchanged.

### Files

- `src/infra/config/index.js` — exports `DEFAULT_ADMIN_PASSWORD`, derives `isProduction` from `NODE_ENV`, and warns when defaults are in use.
- `src/app/createApp.js` — guard runs immediately before `authService.initializePasswordHash()`, the same first-run seeding entry point.
- `.env.example` — new file documenting required + optional env vars with `openssl rand` snippets.
- `README.md` — adds a "Required for first-run in production" callout in the config table, an HTTPS-style note in Security Notes, and a new **Upgrading** section explaining why existing users see no impact.
- `tests/integration/boot-guard.integration.test.js` — four tests covering every path (throws on first-run+production+default; passes if seeded, non-prod, or non-default).

## User impact

**Zero impact on existing users.** The guard's third condition (`!settingsRepository.exists('password_hash')`) means anyone whose `app.db` already has a seeded hash boots normally on next restart — even if they never set `ADMIN_PASSWORD` and the env still resolves to `changeme`. The env var is only consulted to seed the bcrypt hash on the very first run; once seeded, it's never re-read.

**New deployments** must set `ADMIN_PASSWORD` to a strong value before first start. The error message tells them how (`openssl rand -base64 24`).

| Scenario | Before this PR | After this PR |
|---|---|---|
| Existing user, env unset, NODE_ENV=production | Boots, env is irrelevant | Boots, env is irrelevant |
| Existing user, env=changeme | Boots | Boots |
| Fresh install, env unset, NODE_ENV=production | Seeds with `changeme`, vulnerable until login | **Refuses to start** with remediation message |
| Fresh install, env=strongpassword | Seeds normally | Seeds normally |
| Local dev, env unset | Seeds with `changeme` | Seeds with `changeme` + warning |

## Risk

- **Existing prod deployments are unaffected** by design (the guard checks for an existing seeded hash before firing). This is the load-bearing claim — the boot-guard tests exercise it directly.
- **Behaviour change is gated by `NODE_ENV=production`.** Tests, dev, and any caller that doesn't set `isProduction: true` in their config object pass through unchanged. The integration test factory at `tests/integration/auth.integration.test.js:8-16` doesn't set `isProduction`, so all 94 prior tests continue to pass without modification.
- **Coverage holds:** measured statements 91.4%, branches 79.6%, functions 93.0%, lines 91.4% — all above thresholds.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 98/98 passing (94 prior + 4 new)
- [x] `npm run test:ci` — coverage thresholds met
- [ ] Manual: clean dir, no `app.db`, `NODE_ENV=production npm start` with no `ADMIN_PASSWORD` → must refuse to start with remediation message
- [ ] Manual: same clean dir, `NODE_ENV=production ADMIN_PASSWORD=somethingreal npm start` → boots and seeds normally
- [ ] Manual: re-run with the now-existing DB and no `ADMIN_PASSWORD` → boots normally (this is the existing-user path)

## Related

- #338 — CSP / inline scripts shipped separately as #355.
- This PR uses the conventional-commits `BREAKING CHANGE:` footer to trigger semantic-release's major version bump (v1.x → v2.0).

https://claude.ai/code/session_016wAgkh3Z8mcM1ZjGVKTKCn

---
_Generated by [Claude Code](https://claude.ai/code/session_016wAgkh3Z8mcM1ZjGVKTKCn)_