### PR TITLE
feat(security)!: default Secure cookie flag to on in production (#339)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,6 @@ src/
 ### Security (highest priority)
 - Plain text password storage — needs bcrypt migration (story written)
 - `contentSecurityPolicy: false` in Helmet config — needs proper CSP
-- Session cookie missing `secure: true` and `httpOnly: true`
 - Force password change on first login — full story and Codex plan written
 
 ### Code Quality

--- a/README.md
+++ b/README.md
@@ -52,16 +52,40 @@ Open `http://localhost:3000`. On first login you will be prompted to change the 
 | `PORT` | HTTP port the server listens on | `3000` | Runtime server port |
 | `DATABASE_PATH` | Path to the SQLite database file | `/data/app.db` | Defaults to `/data` in Docker |
 | `TRUST_PROXY` | Trust `X-Forwarded-Proto` from a reverse proxy | `false` | Set to `true` when running behind nginx, Caddy, or Traefik |
-| `SECURE_COOKIES` | Set the `Secure` flag on session cookies | `false` | Requires `TRUST_PROXY=true`; only enable when HTTPS is in use |
+| `SECURE_COOKIES` | Set the `Secure` flag on session and CSRF cookies | `true` in production, `false` otherwise | When unset, defaults to `true` whenever `NODE_ENV=production` (the published Docker image always sets this). Set `SECURE_COOKIES=false` to opt out — required if you run the app on plain HTTP in production. Requires `TRUST_PROXY=true` when behind an HTTPS reverse proxy. |
 | `UPDATE_CHECK` | Check GitHub Releases for new versions | `false` | Set to `true` to enable in-app update notifications; results are cached for 14 days |
 
 ## Security Notes
 
-> **Reverse proxy users:** If you are running PPCollection behind nginx,
-> Caddy, or Traefik with HTTPS, set `TRUST_PROXY=true` and
-> `SECURE_COOKIES=true` to enable full cookie security. Do not set
-> `SECURE_COOKIES=true` without a working HTTPS reverse proxy — sessions
-> will silently break.
+> **Reverse proxy users:** If you are running PPCollection behind
+> nginx, Caddy, or Traefik with HTTPS, set `TRUST_PROXY=true`. Secure
+> cookies are now on by default when `NODE_ENV=production` (which is
+> always the case in the published Docker image), so you no longer
+> need to set `SECURE_COOKIES=true` explicitly — but `TRUST_PROXY` is
+> still required so Express recognizes the proxied request as HTTPS,
+> otherwise sessions will silently fail to persist.
+
+> **Plain-HTTP production deployments:** If you intentionally run the
+> app on plain HTTP in production (no TLS terminator at all), the
+> browser will refuse to set or send `Secure` cookies and sessions
+> will break. Set `SECURE_COOKIES=false` to opt out and restore plain
+> session cookies. This is also the upgrade path from earlier versions
+> if you were running on plain HTTP without realizing it.
+
+## Upgrading
+
+Secure session and CSRF cookies are now on by default when
+`NODE_ENV=production`. Before this release the `Secure` flag was
+opt-in via `SECURE_COOKIES=true`. The change is strictly more secure
+for users behind HTTPS but does break sessions for anyone running the
+production image directly on plain HTTP.
+
+| If you run the app... | What you need to do |
+|---|---|
+| Behind an HTTPS reverse proxy with `TRUST_PROXY=true` | Nothing. Cookies were already Secure if you'd set `SECURE_COOKIES=true`; they're Secure now either way. |
+| Behind an HTTPS reverse proxy without `TRUST_PROXY` | Set `TRUST_PROXY=true` so Express honors the `X-Forwarded-Proto` header. The startup log already warns about this combination. |
+| On plain HTTP in production (no TLS) | Add `SECURE_COOKIES=false` to your environment to restore plain cookies. Otherwise sessions will silently fail. |
+| Locally (any non-production `NODE_ENV`) | No change. Default is still off. |
 
 ## Screenshots
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,14 @@ services:
       - ADMIN_USERNAME=${ADMIN_USERNAME:-admin}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-changeme}
       - DATABASE_PATH=/data/app.db
-      # Uncomment the two lines below if you are running behind an HTTPS reverse proxy
+      # Secure cookies are on by default in production (NODE_ENV=production
+      # is hard-set in the Dockerfile). Uncomment TRUST_PROXY when behind an
+      # HTTPS reverse proxy so Express recognises the proxied request as HTTPS.
       # - TRUST_PROXY=true
-      # - SECURE_COOKIES=true
+      # If you intentionally serve the app on plain HTTP (no TLS), uncomment
+      # the line below to disable secure cookies — otherwise the browser will
+      # refuse to send the session cookie and login will not persist.
+      # - SECURE_COOKIES=false
     volumes:
       - ./data:/data
     restart: unless-stopped

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -1,14 +1,22 @@
 const path = require('path');
 
+function resolveSecureCookies(envValue, isProduction) {
+  if (envValue === 'true') return true;
+  if (envValue === 'false') return false;
+  return isProduction;
+}
+
 function getConfig() {
   const trustProxy = process.env.TRUST_PROXY === 'true';
-  const secureCookies = process.env.SECURE_COOKIES === 'true';
+  const isProduction = process.env.NODE_ENV === 'production';
+  const secureCookies = resolveSecureCookies(process.env.SECURE_COOKIES, isProduction);
 
   if (secureCookies && !trustProxy) {
     console.warn(
-      '[config] WARNING: SECURE_COOKIES=true but TRUST_PROXY is not enabled. ' +
-        'Secure cookies require Express to recognize the request as HTTPS (trust proxy). ' +
-        'Sessions may fail to persist. Set TRUST_PROXY=true when running behind an HTTPS reverse proxy.'
+      '[config] WARNING: secure cookies are enabled but TRUST_PROXY is not. ' +
+        'When the app sits behind an HTTPS reverse proxy, Express needs to recognize the request ' +
+        'as HTTPS for the cookie to be sent. Sessions may silently fail to persist. ' +
+        'Set TRUST_PROXY=true, or set SECURE_COOKIES=false to disable secure cookies for this deployment.'
     );
   }
 
@@ -20,6 +28,7 @@ function getConfig() {
     databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db'),
     trustProxy,
     secureCookies,
+    isProduction,
     updateCheck: process.env.UPDATE_CHECK === 'true'
   };
 }

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -1,0 +1,78 @@
+const { getConfig } = require('../../src/infra/config');
+
+describe('getConfig', () => {
+  const originalEnv = { ...process.env };
+  let warnSpy;
+
+  beforeEach(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.SECURE_COOKIES;
+    delete process.env.TRUST_PROXY;
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    warnSpy.mockRestore();
+  });
+
+  describe('secureCookies', () => {
+    test('defaults to true when NODE_ENV=production and SECURE_COOKIES is unset', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.TRUST_PROXY = 'true';
+      const config = getConfig();
+      expect(config.secureCookies).toBe(true);
+    });
+
+    test('defaults to false when NODE_ENV is not production and SECURE_COOKIES is unset', () => {
+      process.env.NODE_ENV = 'development';
+      const config = getConfig();
+      expect(config.secureCookies).toBe(false);
+    });
+
+    test('SECURE_COOKIES=true forces on regardless of NODE_ENV', () => {
+      process.env.NODE_ENV = 'development';
+      process.env.SECURE_COOKIES = 'true';
+      process.env.TRUST_PROXY = 'true';
+      const config = getConfig();
+      expect(config.secureCookies).toBe(true);
+    });
+
+    test('SECURE_COOKIES=false forces off in production (escape hatch)', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.SECURE_COOKIES = 'false';
+      const config = getConfig();
+      expect(config.secureCookies).toBe(false);
+    });
+
+    test('warns when secure cookies are enabled but trust proxy is not', () => {
+      process.env.NODE_ENV = 'production';
+      // TRUST_PROXY left unset → false
+      getConfig();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('TRUST_PROXY'));
+    });
+
+    test('does not warn when secure cookies are disabled', () => {
+      process.env.NODE_ENV = 'development';
+      getConfig();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isProduction', () => {
+    test('is true when NODE_ENV=production', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.TRUST_PROXY = 'true';
+      expect(getConfig().isProduction).toBe(true);
+    });
+
+    test('is false when NODE_ENV is anything else', () => {
+      process.env.NODE_ENV = 'test';
+      expect(getConfig().isProduction).toBe(false);
+    });
+
+    test('is false when NODE_ENV is unset', () => {
+      expect(getConfig().isProduction).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #339. Cookies (session + CSRF) were emitted with `Secure` only when the operator explicitly opted in via `SECURE_COOKIES=true`. Anyone running the published Docker image behind an HTTPS reverse proxy without remembering to set the env override was issuing cookies that could leak over any non-HTTPS subroute (mixed content, downgrade, browser extension probe). Prior issue #283 raised this and was closed when the env var was added — but the safe path was never made the default.

`secureCookies` now derives as:
- `SECURE_COOKIES=true` → on
- `SECURE_COOKIES=false` → off (escape hatch for plain-HTTP prod)
- unset → on when `NODE_ENV=production`, off otherwise

The existing trust-proxy warning was strengthened so it fires on the new implicit-on path too, and the message now points operators at the `SECURE_COOKIES=false` escape hatch.

## User impact

The breaking case is **production-on-plain-HTTP**. The Docker image hard-sets `NODE_ENV=production`, so any operator who runs it bound directly to port 80 with no TLS terminator will see sessions stop persisting (the browser refuses to send `Secure` cookies over plain HTTP). The escape hatch is a one-line env override.

| Scenario | Before | After |
|---|---|---|
| Behind HTTPS proxy with `TRUST_PROXY=true` and `SECURE_COOKIES=true` | Cookie is Secure | Same — no change |
| Behind HTTPS proxy with `TRUST_PROXY=true`, `SECURE_COOKIES` unset | Cookie is **not** Secure | Cookie becomes Secure — strictly more secure, no breakage |
| Behind HTTPS proxy with `SECURE_COOKIES=true` but `TRUST_PROXY=false` | Sessions silently break (existing warning fires) | Same — existing warning fires |
| Plain HTTP in production | Cookie is not Secure | **Sessions break.** Operator must add `SECURE_COOKIES=false`. README's new Upgrading table calls this out. |
| Local dev / non-production | No change | No change |

## Files

- `src/infra/config/index.js` — new `resolveSecureCookies()` helper, `isProduction` field added, warning text updated.
- `tests/unit/config.test.js` (new) — first unit tests against `getConfig`. 9 cases covering all four secureCookies paths and `isProduction` detection.
- `README.md` — config table row, Security Notes section, and a new **Upgrading** section with the impact matrix.
- `docker-compose.yml` — comment block updated to describe the new default and the `SECURE_COOKIES=false` escape hatch.
- `CLAUDE.md` — dropped a stale backlog line claiming `secure: true` and `httpOnly: true` were missing (both have been on for a while; this PR makes Secure on by default in prod).

## Risk

- **Existing integration tests pass without modification** — both `testConfig` and `secureConfig` factories pass config objects directly to `createApp`, bypassing `getConfig` entirely. The "session cookie does NOT have Secure flag when secureCookies=false" test continues to assert the no-secure-flag path correctly because the factory leaves `secureCookies` unset (undefined → falsy).
- **Coverage went up:** statements 93%, branches 83.66%, functions 93.96%, lines 93%. All above thresholds.
- **No middleware change in `createApp.js`** — the `secure: !!config.secureCookies` pattern was already correct; the change is upstream in `getConfig`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 103/103 passing (94 prior + 9 new config tests)
- [x] `npm run test:ci` — coverage thresholds met
- [ ] Manual: `NODE_ENV=production node -e "console.log(require('./src/infra/config').getConfig().secureCookies)"` → `true`
- [ ] Manual: `NODE_ENV=production SECURE_COOKIES=false node -e "..."` → `false`
- [ ] Manual smoke test in Docker: with `NODE_ENV=production`, `TRUST_PROXY=true`, simulating HTTPS via `X-Forwarded-Proto: https` header, `Set-Cookie: connect.sid=...; Secure; HttpOnly; SameSite=Lax` should appear without setting `SECURE_COOKIES=true`.

## Merge target

Targeted at `05012026` per the request. Branched directly off `05012026`, not `main`, so the diff is only the #339 work.

## Related

- #336 (default `SESSION_SECRET`) — separate PR, similar shape but different env var. Not bundled.
- This PR uses the conventional-commits `BREAKING CHANGE:` footer to trigger semantic-release's major version bump.

https://claude.ai/code/session_016wAgkh3Z8mcM1ZjGVKTKCn

---
_Generated by [Claude Code](https://claude.ai/code/session_016wAgkh3Z8mcM1ZjGVKTKCn)_