### PR TITLE
fix(config): refuse to start in production with default SESSION_SECRET

### DIFF
--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -1,6 +1,7 @@
 const path = require('path');
 
 const DEFAULT_ADMIN_PASSWORD = 'changeme';
+const DEFAULT_SESSION_SECRET = 'ppcollection_dev_secret';
 
 function resolveSecureCookies(envValue, isProduction) {
   if (envValue === 'true') return true;
@@ -13,6 +14,7 @@ function getConfig() {
   const isProduction = process.env.NODE_ENV === 'production';
   const secureCookies = resolveSecureCookies(process.env.SECURE_COOKIES, isProduction);
   const adminPass = process.env.ADMIN_PASSWORD || DEFAULT_ADMIN_PASSWORD;
+  const sessionSecret = process.env.SESSION_SECRET || DEFAULT_SESSION_SECRET;
 
   if (secureCookies && !trustProxy) {
     console.warn(
@@ -31,9 +33,22 @@ function getConfig() {
     );
   }
 
+  if (sessionSecret === DEFAULT_SESSION_SECRET) {
+    if (isProduction) {
+      throw new Error(
+        '[config] FATAL: SESSION_SECRET is unset or matches the insecure default. ' +
+          'Set SESSION_SECRET to a random value (e.g. `openssl rand -base64 48`) before starting in production.'
+      );
+    }
+    console.warn(
+      '[config] WARNING: SESSION_SECRET is unset or using the insecure default. ' +
+        'Set SESSION_SECRET to a strong random value before exposing the app.'
+    );
+  }
+
   return {
     port: process.env.PORT ? Number(process.env.PORT) : 3000,
-    sessionSecret: process.env.SESSION_SECRET || 'ppcollection_dev_secret',
+    sessionSecret,
     adminUser: process.env.ADMIN_USERNAME || 'admin',
     adminPass,
     databasePath: process.env.DATABASE_PATH || path.join(process.cwd(), 'data', 'app.db'),

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -9,6 +9,7 @@ describe('getConfig', () => {
     delete process.env.SECURE_COOKIES;
     delete process.env.TRUST_PROXY;
     process.env.ADMIN_PASSWORD = 'test-strong-password-not-default';
+    process.env.SESSION_SECRET = 'test-strong-session-secret-not-default';
     warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
@@ -74,6 +75,45 @@ describe('getConfig', () => {
 
     test('is false when NODE_ENV is unset', () => {
       expect(getConfig().isProduction).toBe(false);
+    });
+  });
+
+  describe('SESSION_SECRET guard', () => {
+    test('uses provided SESSION_SECRET', () => {
+      process.env.SESSION_SECRET = 'my-strong-secret';
+      expect(getConfig().sessionSecret).toBe('my-strong-secret');
+    });
+
+    test('warns in development when SESSION_SECRET is unset', () => {
+      delete process.env.SESSION_SECRET;
+      getConfig();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SESSION_SECRET'));
+    });
+
+    test('warns in development when SESSION_SECRET matches the known default', () => {
+      process.env.SESSION_SECRET = 'ppcollection_dev_secret';
+      getConfig();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('SESSION_SECRET'));
+    });
+
+    test('throws in production when SESSION_SECRET is unset', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.TRUST_PROXY = 'true';
+      delete process.env.SESSION_SECRET;
+      expect(() => getConfig()).toThrow(/SESSION_SECRET/);
+    });
+
+    test('throws in production when SESSION_SECRET matches the known default', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.TRUST_PROXY = 'true';
+      process.env.SESSION_SECRET = 'ppcollection_dev_secret';
+      expect(() => getConfig()).toThrow(/SESSION_SECRET/);
+    });
+
+    test('does not warn when SESSION_SECRET is a custom value', () => {
+      process.env.SESSION_SECRET = 'my-strong-secret';
+      getConfig();
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('SESSION_SECRET'));
     });
   });
 });


### PR DESCRIPTION
## Summary

- In production (`NODE_ENV=production`), throws a fatal error if `SESSION_SECRET` is unset or matches the hard-coded default `ppcollection_dev_secret`, preventing forged session cookies and CSRF tokens on misconfigured deployments
- In development, emits a `console.warn` when using the default secret
- Adds 6 new unit tests covering both paths; all 64 unit tests pass

Closes #336

## Test plan

- [ ] `npm run test:unit` passes (64 tests)
- [ ] Starting the app in production without `SESSION_SECRET` set causes a fatal error at boot
- [ ] Starting the app in development without `SESSION_SECRET` logs a warning but does not crash
- [ ] Starting the app with a custom `SESSION_SECRET` produces no warning

https://claude.ai/code/session_01RJ9tQX3yAbKQfb5vUhms4D

---
_Generated by [Claude Code](https://claude.ai/code/session_01RJ9tQX3yAbKQfb5vUhms4D)_