### PR TITLE
fix(csrf): render friendly 403 with actionable proxy/secure-cookie hint

### DIFF
--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -125,6 +125,35 @@ async function createApp(options = {}) {
 
   app.use(doubleCsrfProtection);
 
+  // Render a friendly 403 page on CSRF rejection and log an actionable hint
+  // when the deployment looks like a reverse-proxy misconfiguration.
+  const proxyMisconfig = config.secureCookies && !config.trustProxy;
+  let csrfMisconfigLogged = false;
+  app.use((err, req, res, next) => {
+    if (err && err.code === 'EBADCSRFTOKEN') {
+      if (proxyMisconfig && !csrfMisconfigLogged) {
+        csrfMisconfigLogged = true;
+        console.error(
+          '[csrf] Rejected a request because the CSRF cookie was missing. ' +
+            'Secure cookies are enabled but TRUST_PROXY is not set, so the cookie is never delivered ' +
+            'over a reverse-proxied HTTPS connection. ' +
+            'Set TRUST_PROXY=true on the container, or set SECURE_COOKIES=false for plain-HTTP deployments.'
+        );
+      }
+      // The locals middleware runs after CSRF, so on rejection we populate
+      // the layout's required values manually before rendering.
+      res.locals.user = req.session?.user || null;
+      res.locals.currentPath = req.path;
+      res.locals.csrfToken = null;
+      res.locals.theme = authService.getTheme();
+      res.locals.updateCheckAllowed = config.updateCheck;
+      res.locals.updateCheckEnabled = authService.getUpdateCheckEnabled();
+      res.locals.versionInfo = { currentVersion: version, latestVersion: null, updateAvailable: false };
+      return res.status(403).render('errors/403', { proxyHint: proxyMisconfig });
+    }
+    return next(err);
+  });
+
   app.use('/', express.static(path.join(__dirname, '..', 'public')));
   app.use('/static', express.static(path.join(__dirname, '..', 'public')));
 

--- a/src/views/errors/403-content.ejs
+++ b/src/views/errors/403-content.ejs
@@ -1,0 +1,16 @@
+<section class="app-hero">
+  <h2 class="page-title">Request Blocked</h2>
+  <p class="page-subtitle">Your session could not be verified. This usually means your login form expired or your browser dropped a security cookie.</p>
+</section>
+
+<section class="card empty-state">
+  <h3>Try again</h3>
+  <p>Go back to the login page and submit the form again. If the problem persists immediately after restarting the container, the app is likely behind an HTTPS reverse proxy without trust-proxy configured.</p>
+  <% if (typeof proxyHint !== 'undefined' && proxyHint) { %>
+    <p><strong>Operator hint:</strong> set <code>TRUST_PROXY=true</code> on the container if it sits behind an HTTPS reverse proxy, or set <code>SECURE_COOKIES=false</code> if you are accessing it over plain HTTP. See the README for details.</p>
+  <% } %>
+  <div class="empty-state-actions">
+    <a class="btn" href="/login">Back to Login</a>
+    <a class="btn btn-secondary" href="/">Go Home</a>
+  </div>
+</section>

--- a/src/views/errors/403.ejs
+++ b/src/views/errors/403.ejs
@@ -1,0 +1,4 @@
+<%
+  const content = include('./403-content');
+%>
+<%- include('../partials/layout', { ...locals, body: content, pageTitle: 'Request Blocked' }) %>

--- a/tests/integration/auth.integration.test.js
+++ b/tests/integration/auth.integration.test.js
@@ -672,3 +672,61 @@ describe('cookie security flags', () => {
     app.locals.db.close();
   });
 });
+
+describe('CSRF rejection rendering', () => {
+  let dbPath;
+
+  afterEach(() => {
+    if (dbPath) {
+      const dir = path.dirname(dbPath);
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('renders friendly 403 page when CSRF token is missing', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-csrf-'));
+    dbPath = path.join(tempDir, 'app.db');
+    const app = await createApp({ config: testConfig(dbPath) });
+
+    const response = await request(app).post('/login').type('form').send({ username: 'admin', password: 'password123' });
+
+    expect(response.status).toBe(403);
+    expect(response.text).toContain('Request Blocked');
+    expect(response.text).toContain('href="/login"');
+    expect(response.text).not.toContain('Operator hint');
+
+    app.locals.db.close();
+  });
+
+  test('shows operator hint when secureCookies=true and trustProxy=false', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-csrf-'));
+    dbPath = path.join(tempDir, 'app.db');
+    const app = await createApp({
+      config: {
+        port: 0,
+        sessionSecret: 'test-secret',
+        adminUser: 'admin',
+        adminPass: 'password123',
+        databasePath: dbPath,
+        trustProxy: false,
+        secureCookies: true
+      }
+    });
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const response = await request(app)
+      .post('/login')
+      .set('X-Forwarded-Proto', 'https')
+      .type('form')
+      .send({ username: 'admin', password: 'password123' });
+
+    expect(response.status).toBe(403);
+    expect(response.text).toContain('Operator hint');
+    expect(response.text).toContain('TRUST_PROXY=true');
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('TRUST_PROXY=true'));
+
+    errorSpy.mockRestore();
+    app.locals.db.close();
+  });
+});


### PR DESCRIPTION
## Summary
- Catch `EBADCSRFTOKEN` from `csrf-csrf` and render a new `errors/403` EJS page instead of the default plain-text "Forbidden" body.
- When the deployment looks like the classic reverse-proxy misconfiguration (`SECURE_COOKIES=true` + no `TRUST_PROXY`), include an inline operator hint on the page and log a single actionable line on the first occurrence pointing at `TRUST_PROXY=true` / `SECURE_COOKIES=false`.

## Why
Reported in the field: a user behind an HTTPS reverse proxy on Unraid (e.g. `https://pewpewcollection.gogorichie.online`) updated to the new container, hit `POST /login`, and got a bare 403 because Express was treating the proxied connection as HTTP and dropping the secure CSRF cookie. The startup warning that explains the fix is easy to miss in the log scroll, and the runtime failure surface gave them no path forward.

## Test plan
- [x] `npm test` — 115/115 pass, including two new integration cases:
  - `renders friendly 403 page when CSRF token is missing`
  - `shows operator hint when secureCookies=true and trustProxy=false`
- [x] `npm run lint`
- [ ] Manual: deploy with `SECURE_COOKIES=true` and no `TRUST_PROXY`; confirm the new 403 page renders and the hint shows up exactly once in the container log.

https://claude.ai/code/session_01FzgU8nVSnJkk7tBC8iCVLT

---
_Generated by [Claude Code](https://claude.ai/code/session_01FzgU8nVSnJkk7tBC8iCVLT)_