### PR TITLE
ci(release): lowercase image ref before SBOM scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,10 +297,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Compute lowercase image reference
+        id: image_ref
+        env:
+          REPOSITORY: ${{ github.repository }}
+          VERSION: ${{ needs.publish.outputs.new_release_version }}
+        run: echo "ref=ghcr.io/${REPOSITORY,,}:${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Generate SBOM (CycloneDX)
         uses: anchore/sbom-action@v0
         with:
-          image: ghcr.io/${{ github.repository }}:${{ needs.publish.outputs.new_release_version }}
+          image: ${{ steps.image_ref.outputs.ref }}
           format: cyclonedx-json
           output-file: sbom.cdx.json
 


### PR DESCRIPTION
## Summary

The 2.1.1 release run failed at the SBOM step in the `docker` job:

```
ERROR could not determine source: errors occurred attempting to resolve
'ghcr.io/Gogorichielab/PPCollection:2.1.1':
  - docker: could not parse reference: ghcr.io/Gogorichielab/PPCollection:2.1.1
The process '/opt/hostedtoolcache/syft/1.42.3/x64/syft' failed with exit code 1
```

### Root cause

The Docker push steps survive mixed-case repository names because `docker/metadata-action` normalises `ghcr.io/${{ github.repository }}` to lowercase (you can see `ghcr.io/gogorichielab/ppcollection:2.1.1` in the build/push logs). The SBOM step skips that helper and feeds the raw `github.repository` (`Gogorichielab/PPCollection`) directly to syft, which enforces the OCI lowercase-reference rule and bails out.

The image itself was published successfully — only the SBOM attachment to the GitHub Release failed.

### Fix

Compute the lowercase image reference once via bash's `${VAR,,}` and reuse it in the SBOM step. The Docker build/push and the `softprops/action-gh-release` step are unchanged.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Trigger a re-run of the failing workflow against this branch (or wait for the next release commit) and confirm the SBOM step finds the image and uploads `sbom.cdx.json` to the GitHub Release
- [ ] Confirm subsequent steps in the `docker` job complete (the `Attach SBOM to GitHub Release` step is what consumes `sbom.cdx.json`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01TXtEUWgwqvVsEVsahkAsqo)_