### PR TITLE
ci(codeowners): add owner review policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default: project owner reviews everything not otherwise matched
+*                              @gogorichie
+
+# CI/CD and release plumbing — owner approval required
+/.github/                      @gogorichie
+/Dockerfile                    @gogorichie
+/docker-compose.yml            @gogorichie
+/.releaserc.json               @gogorichie
+/.releaserc.publish.json       @gogorichie
+
+# Schema changes — never auto-merge, never bot-merge
+/src/infra/db/migrations/      @gogorichie

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,8 @@ BREAKING CHANGE: the /api/v1 endpoint has been removed
 
 The repository uses `.github/CODEOWNERS` to request owner review automatically. The default owner reviews all changes, with explicit ownership for high-blast-radius files and directories such as GitHub Actions configuration, Docker runtime files, semantic-release configuration, and database migrations.
 
-Maintainers should pair this file with a branch-protection rule on `main` that requires Code Owner review before merge.
+Maintainers should pair this file with a branch-protection rule on
+`main` that requires Code Owner review before merge.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,12 @@ BREAKING CHANGE: the /api/v1 endpoint has been removed
 6. Wait for CI checks to pass
 7. Reference any related issues in the PR description
 
+### Code Owner Review Policy
+
+The repository uses `.github/CODEOWNERS` to request owner review automatically. The default owner reviews all changes, with explicit ownership for high-blast-radius files and directories such as GitHub Actions configuration, Docker runtime files, semantic-release configuration, and database migrations.
+
+Maintainers should pair this file with a branch-protection rule on `main` that requires Code Owner review before merge.
+
 ---
 
 ## Release Process

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Full documentation: [https://gogorichielab.github.io/PPCollection/](https://gogo
 
 Contributing guide: [CONTRIBUTING.md](CONTRIBUTING.md)
 
+PPCollection uses `.github/CODEOWNERS` to request maintainer review automatically, especially for high-blast-radius areas such as GitHub Actions configuration, Docker runtime files, release configuration, and database migrations. Maintainers should enable branch protection on `main` that requires Code Owner review before merge.
+
 ## License
 
 Licensed under GNU GPL v3 or later: [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,11 @@ Full documentation: [https://gogorichielab.github.io/PPCollection/](https://gogo
 
 Contributing guide: [CONTRIBUTING.md](CONTRIBUTING.md)
 
-PPCollection uses `.github/CODEOWNERS` to request maintainer review automatically, especially for high-blast-radius areas such as GitHub Actions configuration, Docker runtime files, release configuration, and database migrations. Maintainers should enable branch protection on `main` that requires Code Owner review before merge.
+PPCollection uses `.github/CODEOWNERS` to request maintainer review
+automatically, especially for high-blast-radius areas such as GitHub Actions
+configuration, Docker runtime files, release configuration, and database
+migrations. Maintainers should enable branch protection on `main` that
+requires Code Owner review before merge.
 
 ## License
 


### PR DESCRIPTION
### Motivation
- The repository had no `CODEOWNERS` file, leaving high-blast-radius areas (workflows, Docker runtime, release config, and DB migrations) without automatic owner review.
- Enforce a single maintainer as the default reviewer to reduce risk from accidental or automated merges in sensitive files.

### Description
- Add `.github/CODEOWNERS` that sets `@gogorichie` as the default owner and explicitly assigns ownership for `/.github/`, `/Dockerfile`, `/docker-compose.yml`, `/.releaserc.json`, `/.releaserc.publish.json`, and `/src/infra/db/migrations/`.
- Document the Code Owner review policy in `CONTRIBUTING.md` so contributors know the expectation for owner reviews.
- Add a short note to `README.md` indicating the repo uses `CODEOWNERS` for maintainer review and recommending enabling branch protection on `main` that requires Code Owner review.
- Note that enabling branch-protection in repository settings is still required to enforce the policy.

### Testing
- Performed a local CODEOWNERS syntax sanity check with a small `python` validator, which passed.
- Ran `npm run lint`, which completed successfully without blocking issues.
- Ran the full test suite with `npm test`, and all tests passed (`Test Suites: 15 passed, Tests: 141 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5d6515e483329afe2fdef663ab49)