### PR TITLE
feat(ux): inventory table & filtering improvements (Epic #460)

### DIFF
--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1045,6 +1045,53 @@ main:focus-visible {
   outline-offset: 2px;
 }
 
+details.filter-group > summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  user-select: none;
+  margin-bottom: 8px;
+}
+
+details.filter-group > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.filter-group > summary::after {
+  content: '▾';
+  color: var(--text-faint);
+  transition: transform 0.2s;
+}
+
+details.filter-group[open] > summary::after {
+  transform: rotate(-180deg);
+}
+
+.filter-chip--overflow {
+  display: none;
+}
+
+.filter-options--expanded .filter-chip--overflow {
+  display: inline-flex;
+}
+
+.filter-show-more {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: 6px 10px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-muted);
+  background: none;
+}
+
+.filter-show-more:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .active-filters {
   display: flex;
   flex-wrap: wrap;
@@ -1974,5 +2021,9 @@ main:focus-visible {
 
   .home-chart-wrap canvas {
     height: 220px;
+  }
+
+  .filter-group {
+    min-width: 100%;
   }
 }

--- a/src/public/js/search.js
+++ b/src/public/js/search.js
@@ -38,6 +38,15 @@
     row.dataset.index = index;
   });
 
+  // Module-level sort state for Issue #400
+  let currentSort = { column: null, direction: 'none' };
+
+  // Debounce timer for Issue #402
+  let searchDebounce;
+
+  // Allowed sort column keys for Issue #435
+  const ALLOWED_SORT_KEYS = ['make', 'model', 'caliber', 'serial', 'purchase_date', 'status', 'firearm_type'];
+
   function setSortIcon(button, direction) {
     const icon = button.querySelector('.sort-icon');
 
@@ -174,15 +183,96 @@
     });
   }
 
+  // Issue #435: Update pagination links to include current filter params
+  function updatePaginationLinks(currentParams) {
+    const paginationBtns = document.querySelectorAll('.pagination-btn[href]');
+    paginationBtns.forEach((btn) => {
+      const url = new URL(btn.href, location.href);
+      const page = url.searchParams.get('page');
+      const merged = new URLSearchParams(currentParams);
+      if (page) {
+        merged.set('page', page);
+      } else {
+        merged.delete('page');
+      }
+      const qs = merged.toString();
+      btn.href = qs ? `?${qs}` : location.pathname;
+    });
+  }
+
+  // Issue #435: Sync current filter/sort state to URL
+  function syncUrl() {
+    const params = new URLSearchParams();
+    if (searchInput.value) params.set('q', searchInput.value);
+    if (searchField.value !== 'all') params.set('field', searchField.value);
+    Object.entries(getSelectedFacets()).forEach(([facet, vals]) => {
+      if (vals.length) params.set(facet, vals.join(','));
+    });
+    if (currentSort.column && currentSort.direction !== 'none') {
+      params.set('sort', `${currentSort.column}:${currentSort.direction}`);
+    }
+    const qs = params.toString();
+    history.replaceState(null, '', qs ? `?${qs}` : location.pathname);
+    updatePaginationLinks(params);
+  }
+
+  // Issue #435: Restore state from URL params on load
+  function hydrateFromUrl() {
+    const params = new URLSearchParams(location.search);
+
+    const q = params.get('q');
+    if (q) searchInput.value = q;
+
+    const field = params.get('field');
+    if (field) searchField.value = field;
+
+    // Restore facet checkboxes
+    facetInputs.forEach((input) => {
+      const facet = input.dataset.facet;
+      if (!facet) return;
+      const paramVal = params.get(facet);
+      if (paramVal) {
+        const vals = paramVal.split(',').map((v) => v.toLowerCase());
+        if (vals.includes(input.value.toLowerCase())) {
+          input.checked = true;
+        }
+      }
+    });
+
+    // Restore sort state
+    const sort = params.get('sort');
+    if (sort) {
+      const [col, dir] = sort.split(':');
+      if (ALLOWED_SORT_KEYS.includes(col) && (dir === 'asc' || dir === 'desc')) {
+        currentSort = { column: col, direction: dir };
+        // Update button UI
+        sortButtons.forEach((button) => {
+          if (button.dataset.sortKey === col) {
+            button.dataset.direction = dir;
+            const th = button.closest('th');
+            if (th) {
+              th.setAttribute('aria-sort', dir === 'asc' ? 'ascending' : 'descending');
+            }
+            button.classList.toggle('sorted-asc', dir === 'asc');
+            button.classList.toggle('sorted-desc', dir === 'desc');
+            setSortIcon(button, dir);
+          }
+        });
+      }
+    }
+
+    updateClearVisibility();
+  }
+
   function performSearch() {
     const searchTerm = searchInput.value.toLowerCase().trim();
     const field = searchField.value;
-    const rows = tbody.getElementsByTagName('tr');
+    const currentRows = tbody.getElementsByTagName('tr');
     const selectedFacets = getSelectedFacets();
     let visibleCount = 0;
 
-    for (let i = 0; i < rows.length; i++) {
-      const row = rows[i];
+    for (let i = 0; i < currentRows.length; i++) {
+      const row = currentRows[i];
       let matchesSearch = false;
 
       if (searchTerm === '') {
@@ -224,6 +314,14 @@
 
     updateActiveFilters(selectedFacets);
     updateStatus(visibleCount);
+
+    // Issue #400: Re-apply sort after filtering
+    if (currentSort.column && currentSort.direction !== 'none') {
+      sortRows(currentSort.column, currentSort.direction);
+    }
+
+    // Issue #435: Sync URL
+    syncUrl();
   }
 
   function resetSorting() {
@@ -235,9 +333,10 @@
       setSortIcon(button, 'none');
     });
 
-    const sortedRows = Array.from(tbody.rows).sort((a, b) => {
-      return Number(a.dataset.index) - Number(b.dataset.index);
-    });
+    // Issue #400: Reset currentSort state
+    currentSort = { column: null, direction: 'none' };
+
+    const sortedRows = Array.from(tbody.rows).sort((a, b) => Number(a.dataset.index) - Number(b.dataset.index));
 
     sortedRows.forEach((row) => tbody.appendChild(row));
   }
@@ -304,6 +403,58 @@
     button.classList.toggle('sorted-asc', nextDirection === 'asc');
     button.classList.toggle('sorted-desc', nextDirection === 'desc');
     setSortIcon(button, nextDirection);
+
+    // Issue #400: Update currentSort state
+    if (nextDirection === 'none') {
+      currentSort = { column: null, direction: 'none' };
+    } else {
+      currentSort = { column: key, direction: nextDirection };
+    }
+
+    // Issue #435: Sync URL after sort change
+    syncUrl();
+  }
+
+  // Issue #441: Initialize collapsible filter groups
+  function initFilterGroups() {
+    const filterGroups = document.querySelectorAll('details.filter-group');
+
+    filterGroups.forEach((details) => {
+      const facet = details.dataset.facetGroup;
+
+      // Restore open/closed state from localStorage
+      if (facet) {
+        const stored = localStorage.getItem(`filter-group-${facet}`);
+        if (stored === 'open') {
+          details.open = true;
+        } else if (stored === 'closed') {
+          details.open = false;
+        }
+      }
+
+      // Save state on toggle
+      details.addEventListener('toggle', () => {
+        if (facet) {
+          localStorage.setItem(`filter-group-${facet}`, details.open ? 'open' : 'closed');
+        }
+      });
+
+      // Handle show-more buttons
+      const showMoreBtn = details.querySelector('.filter-show-more');
+      if (showMoreBtn) {
+        const filterOptions = details.querySelector('.filter-options');
+        const overflowCount = Number.parseInt(showMoreBtn.dataset.overflowCount, 10) || 0;
+
+        showMoreBtn.addEventListener('click', () => {
+          const isExpanded = filterOptions && filterOptions.classList.toggle('filter-options--expanded');
+          if (isExpanded) {
+            showMoreBtn.textContent = 'Show less';
+          } else {
+            showMoreBtn.textContent = `+${overflowCount} more`;
+          }
+        });
+      }
+    });
   }
 
   function resetFilters() {
@@ -313,6 +464,19 @@
       input.checked = false;
     });
     resetSorting();
+
+    // Issue #441: Collapse expanded show-more groups back to default state
+    document.querySelectorAll('.filter-options--expanded').forEach((filterOptions) => {
+      filterOptions.classList.remove('filter-options--expanded');
+      const showMoreBtn = filterOptions.parentElement
+        ? filterOptions.parentElement.querySelector('.filter-show-more')
+        : null;
+      if (showMoreBtn) {
+        const overflowCount = Number.parseInt(showMoreBtn.dataset.overflowCount, 10) || 0;
+        showMoreBtn.textContent = `+${overflowCount} more`;
+      }
+    });
+
     performSearch();
     searchInput.focus();
   }
@@ -323,9 +487,12 @@
   }
 
   // Add event listeners
+
+  // Issue #402: Debounce search input
   searchInput.addEventListener('input', () => {
     updateClearVisibility();
-    performSearch();
+    clearTimeout(searchDebounce);
+    searchDebounce = setTimeout(performSearch, 250);
   });
   searchField.addEventListener('change', performSearch);
 
@@ -363,7 +530,7 @@
 
     const row = event.currentTarget;
     const firearmId = row.dataset.firearmId;
-    
+
     if (firearmId) {
       window.location.href = `/firearms/${firearmId}`;
     }
@@ -384,5 +551,12 @@
   });
 
   updateClearVisibility();
+
+  // Issue #441: Init filter groups before first search
+  initFilterGroups();
+
+  // Issue #435: Restore state from URL before first search
+  hydrateFromUrl();
+
   performSearch();
 })();

--- a/src/views/firearms/index-content.ejs
+++ b/src/views/firearms/index-content.ejs
@@ -58,47 +58,57 @@
         </div>
       </div>
 
+      <% const MAX_VISIBLE = 6; %>
       <div class="filter-groups" aria-label="Filters">
         <% if (statusOptions.length) { %>
-          <div class="filter-group" data-facet-group="status">
-            <div class="filter-label label-caps">Status</div>
+          <details class="filter-group" data-facet-group="status"<%= statusOptions.length <= MAX_VISIBLE ? ' open' : '' %>>
+            <summary class="filter-label label-caps">Status</summary>
             <div class="filter-options">
-              <% statusOptions.forEach((status) => { %>
-                <label class="filter-chip">
+              <% statusOptions.forEach((status, idx) => { %>
+                <label class="filter-chip<%= idx >= MAX_VISIBLE ? ' filter-chip--overflow' : '' %>">
                   <input type="checkbox" class="facet-input" value="<%= status %>" data-facet="status">
                   <span><%= status %></span>
                 </label>
               <% }) %>
+              <% if (statusOptions.length > MAX_VISIBLE) { %>
+                <button type="button" class="filter-show-more" data-overflow-count="<%= statusOptions.length - MAX_VISIBLE %>">+<%= statusOptions.length - MAX_VISIBLE %> more</button>
+              <% } %>
             </div>
-          </div>
+          </details>
         <% } %>
 
         <% if (conditionOptions.length) { %>
-          <div class="filter-group" data-facet-group="condition">
-            <div class="filter-label label-caps">Condition</div>
+          <details class="filter-group" data-facet-group="condition"<%= conditionOptions.length <= MAX_VISIBLE ? ' open' : '' %>>
+            <summary class="filter-label label-caps">Condition</summary>
             <div class="filter-options">
-              <% conditionOptions.forEach((condition) => { %>
-                <label class="filter-chip">
+              <% conditionOptions.forEach((condition, idx) => { %>
+                <label class="filter-chip<%= idx >= MAX_VISIBLE ? ' filter-chip--overflow' : '' %>">
                   <input type="checkbox" class="facet-input" value="<%= condition %>" data-facet="condition">
                   <span><%= condition %></span>
                 </label>
               <% }) %>
+              <% if (conditionOptions.length > MAX_VISIBLE) { %>
+                <button type="button" class="filter-show-more" data-overflow-count="<%= conditionOptions.length - MAX_VISIBLE %>">+<%= conditionOptions.length - MAX_VISIBLE %> more</button>
+              <% } %>
             </div>
-          </div>
+          </details>
         <% } %>
 
         <% if (firearmTypeOptions.length) { %>
-          <div class="filter-group" data-facet-group="firearm_type">
-            <div class="filter-label label-caps">Firearm Type</div>
+          <details class="filter-group" data-facet-group="firearm_type"<%= firearmTypeOptions.length <= MAX_VISIBLE ? ' open' : '' %>>
+            <summary class="filter-label label-caps">Firearm Type</summary>
             <div class="filter-options">
-              <% firearmTypeOptions.forEach((firearmType) => { %>
-                <label class="filter-chip">
+              <% firearmTypeOptions.forEach((firearmType, idx) => { %>
+                <label class="filter-chip<%= idx >= MAX_VISIBLE ? ' filter-chip--overflow' : '' %>">
                   <input type="checkbox" class="facet-input" value="<%= firearmType %>" data-facet="firearm_type">
                   <span><%= firearmType %></span>
                 </label>
               <% }) %>
+              <% if (firearmTypeOptions.length > MAX_VISIBLE) { %>
+                <button type="button" class="filter-show-more" data-overflow-count="<%= firearmTypeOptions.length - MAX_VISIBLE %>">+<%= firearmTypeOptions.length - MAX_VISIBLE %> more</button>
+              <% } %>
             </div>
-          </div>
+          </details>
         <% } %>
       </div>
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements all sub-issues from Epic #460 — Inventory Table & Filtering.

**Already shipped (confirmed in codebase):**
- #454 — Status and Firearm Type columns already present in the table with colored badges
- #455 — Row click handler and pointer cursor already wired up

**Implemented in this PR:**
- **#400** — Sort state no longer resets when a filter chip is applied. `currentSort` is tracked at module level and `performSearch()` re-applies it after each filter pass.
- **#402** — Search input is debounced at 250 ms, preventing layout thrashing on large collections.
- **#435** — Filter, search, and sort state is mirrored to the URL via `history.replaceState()`. State is restored from `URLSearchParams` on page load (survives refresh and browser back). Pagination links are updated to carry current filter params so paging preserves active filters.
- **#441** — Filter chip groups are wrapped in native `<details>/<summary>` for collapse/expand. Open/closed state persists in `localStorage` per facet. Groups with more than 6 chips show a "+N more" expander button.

## Test plan

- [ ] Apply a status filter, then sort by Make — sort should survive subsequent filter changes
- [ ] Type in the search box rapidly — no visible jank; search fires ~250 ms after last keystroke
- [ ] Apply filters + sort, then refresh the page — state is restored from URL
- [ ] Copy the URL while filtered and open it in a new tab — same filters apply
- [ ] With pagination active, filter/sort, then click Next — filters carry through to next page
- [ ] Expand/collapse a filter group — state persists after page refresh
- [ ] With a collection of >6 conditions, click "+N more" to reveal overflow chips; click "Show less" to collapse
- [ ] Click "Clear all" — expanded show-more groups collapse back to default

Closes #400, #402, #435, #441
Part of #460
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SepHai8Ga1MwFpmzZdEyoe)_