### PR TITLE
feat(firearms): group form fields into sections and fix detail page notes markup

### DIFF
--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -427,6 +427,24 @@ button.card:hover,
   resize: vertical;
 }
 
+.form-section {
+  border: none;
+  border-top: 1px solid var(--border);
+  padding: 16px 0 0;
+  margin: 0 0 4px;
+  min-width: 0;
+}
+
+.form-section:first-of-type {
+  border-top: none;
+  padding-top: 0;
+}
+
+.form-section > legend {
+  margin-bottom: 10px;
+  padding: 0;
+}
+
 .form-actions {
   margin-top: 14px;
   display: flex;

--- a/src/views/firearms/_form.ejs
+++ b/src/views/firearms/_form.ejs
@@ -1,67 +1,107 @@
-<div>
-  <label for="firearm-make">Make <span class="required-marker">*</span></label>
-  <input id="firearm-make" name="make" required aria-required="true" aria-invalid="<%= fieldErrors && fieldErrors.make ? 'true' : 'false' %>" value="<%= item.make || '' %>">
-  <% if (fieldErrors && fieldErrors.make) { %>
-    <small class="field-error"><%= fieldErrors.make %></small>
-  <% } %>
-</div>
-<div>
-  <label for="firearm-model">Model <span class="required-marker">*</span></label>
-  <input id="firearm-model" name="model" required aria-required="true" aria-invalid="<%= fieldErrors && fieldErrors.model ? 'true' : 'false' %>" value="<%= item.model || '' %>">
-  <% if (fieldErrors && fieldErrors.model) { %>
-    <small class="field-error"><%= fieldErrors.model %></small>
-  <% } %>
-</div>
-<div>
-  <label for="firearm-serial">Serial</label>
-  <input id="firearm-serial" name="serial" placeholder="e.g., ABC123456" value="<%= item.serial || '' %>">
-  <small class="helper-text">Optional: Enter the firearm's serial number</small>
-</div>
-<div>
-  <label for="firearm-caliber">Caliber</label>
-  <input id="firearm-caliber" name="caliber" placeholder="e.g., 9mm, .45 ACP, 12 gauge" value="<%= item.caliber || '' %>">
-  <small class="helper-text">Optional: Enter caliber or gauge</small>
-</div>
-<div>
-  <label for="firearm-purchase-date">Purchase Date</label>
-  <input id="firearm-purchase-date" type="date" name="purchase_date" value="<%= item.purchase_date || '' %>">
-  <small class="helper-text">Select purchase date using the calendar picker</small>
-</div>
-<div>
-  <label for="firearm-purchase-price">Purchase Price</label>
-  <input id="firearm-purchase-price" type="number" step="0.01" min="0" name="purchase_price" placeholder="0.00" value="<%= item.purchase_price ?? '' %>" aria-invalid="<%= fieldErrors && fieldErrors.purchase_price ? 'true' : 'false' %>">
-  <% if (fieldErrors && fieldErrors.purchase_price) { %>
-    <small class="field-error"><%= fieldErrors.purchase_price %></small>
-  <% } %>
-  <small class="helper-text">Enter price in USD (e.g., 599.99)</small>
-</div>
-<div>
-  <label for="firearm-condition">Purchase Condition</label>
-  <select id="firearm-condition" name="condition">
-    <option value="">Select...</option>
-    <option value="New" <%= (item.condition === 'New') ? 'selected' : '' %>>New</option>
-    <option value="Used" <%= (item.condition === 'Used') ? 'selected' : '' %>>Used</option>
-    <option value="Broken" <%= (item.condition === 'Broken') ? 'selected' : '' %>>Broken</option>
-  </select>
-</div>
-<div>
-  <label for="firearm-location">Location</label>
-  <input id="firearm-location" name="location" value="<%= item.location || '' %>">
-  <small class="helper-text">Optional: Storage location or range bag.</small>
-</div>
-<div>
-  <label for="firearm-status">Status</label>
-  <select id="firearm-status" name="status">
-    <option value="">Select...</option>
-    <option value="Active" <%= (item.status === 'Active') ? 'selected' : '' %>>Active</option>
-    <option value="In Transit" <%= (item.status === 'In Transit') ? 'selected' : '' %>>In Transit</option>
-    <option value="Sold" <%= (item.status === 'Sold') ? 'selected' : '' %>>Sold</option>
-    <option value="Lost/Stolen" <%= (item.status === 'Lost/Stolen') ? 'selected' : '' %>>Lost/Stolen</option>
-    <option value="Under Repair" <%= (item.status === 'Under Repair') ? 'selected' : '' %>>Under Repair</option>
-  </select>
-  <small class="helper-text">Current ownership or maintenance state.</small>
-</div>
-<div class="col-span-2 disposition-section <%= (item.status === 'Sold' || item.status === 'Lost/Stolen') ? '' : 'hidden' %>">
+<fieldset class="form-section">
+  <legend class="section-header label-caps">Profile</legend>
+  <div class="grid">
+    <div>
+      <label for="firearm-make">Make <span class="required-marker">*</span></label>
+      <input id="firearm-make" name="make" required aria-required="true" aria-invalid="<%= fieldErrors && fieldErrors.make ? 'true' : 'false' %>" value="<%= item.make || '' %>">
+      <% if (fieldErrors && fieldErrors.make) { %>
+        <small class="field-error"><%= fieldErrors.make %></small>
+      <% } %>
+    </div>
+    <div>
+      <label for="firearm-model">Model <span class="required-marker">*</span></label>
+      <input id="firearm-model" name="model" required aria-required="true" aria-invalid="<%= fieldErrors && fieldErrors.model ? 'true' : 'false' %>" value="<%= item.model || '' %>">
+      <% if (fieldErrors && fieldErrors.model) { %>
+        <small class="field-error"><%= fieldErrors.model %></small>
+      <% } %>
+    </div>
+    <div>
+      <label for="firearm-serial">Serial</label>
+      <input id="firearm-serial" name="serial" placeholder="e.g., ABC123456" value="<%= item.serial || '' %>">
+      <small class="helper-text">Optional: Enter the firearm's serial number</small>
+    </div>
+    <div>
+      <label for="firearm-caliber">Caliber</label>
+      <input id="firearm-caliber" name="caliber" placeholder="e.g., 9mm, .45 ACP, 12 gauge" value="<%= item.caliber || '' %>">
+      <small class="helper-text">Optional: Enter caliber or gauge</small>
+    </div>
+    <div>
+      <label for="firearm-location">Location</label>
+      <input id="firearm-location" name="location" value="<%= item.location || '' %>">
+      <small class="helper-text">Optional: Storage location or range bag.</small>
+    </div>
+  </div>
+</fieldset>
+
+<fieldset class="form-section">
+  <legend class="section-header label-caps">Purchase</legend>
+  <div class="grid">
+    <div>
+      <label for="firearm-purchase-date">Purchase Date</label>
+      <input id="firearm-purchase-date" type="date" name="purchase_date" value="<%= item.purchase_date || '' %>">
+      <small class="helper-text">Select purchase date using the calendar picker</small>
+    </div>
+    <div>
+      <label for="firearm-purchase-price">Purchase Price</label>
+      <input id="firearm-purchase-price" type="number" step="0.01" min="0" name="purchase_price" placeholder="0.00" value="<%= item.purchase_price ?? '' %>" aria-invalid="<%= fieldErrors && fieldErrors.purchase_price ? 'true' : 'false' %>">
+      <% if (fieldErrors && fieldErrors.purchase_price) { %>
+        <small class="field-error"><%= fieldErrors.purchase_price %></small>
+      <% } %>
+      <small class="helper-text">Enter price in USD (e.g., 599.99)</small>
+    </div>
+    <div>
+      <label for="firearm-condition">Purchase Condition</label>
+      <select id="firearm-condition" name="condition">
+        <option value="">Select...</option>
+        <option value="New" <%= (item.condition === 'New') ? 'selected' : '' %>>New</option>
+        <option value="Used" <%= (item.condition === 'Used') ? 'selected' : '' %>>Used</option>
+        <option value="Broken" <%= (item.condition === 'Broken') ? 'selected' : '' %>>Broken</option>
+      </select>
+    </div>
+  </div>
+</fieldset>
+
+<fieldset class="form-section">
+  <legend class="section-header label-caps">Ownership</legend>
+  <div class="grid">
+    <div>
+      <label for="firearm-status">Status</label>
+      <select id="firearm-status" name="status">
+        <option value="">Select...</option>
+        <option value="Active" <%= (item.status === 'Active') ? 'selected' : '' %>>Active</option>
+        <option value="In Transit" <%= (item.status === 'In Transit') ? 'selected' : '' %>>In Transit</option>
+        <option value="Sold" <%= (item.status === 'Sold') ? 'selected' : '' %>>Sold</option>
+        <option value="Lost/Stolen" <%= (item.status === 'Lost/Stolen') ? 'selected' : '' %>>Lost/Stolen</option>
+        <option value="Under Repair" <%= (item.status === 'Under Repair') ? 'selected' : '' %>>Under Repair</option>
+      </select>
+      <small class="helper-text">Current ownership or maintenance state.</small>
+    </div>
+    <div>
+      <label for="firearm-firearm-type">Firearm Type</label>
+      <select id="firearm-firearm-type" name="firearm_type">
+        <option value="">Select...</option>
+        <option value="Rifle" <%= (item.firearm_type === 'Rifle') ? 'selected' : '' %>>Rifle</option>
+        <option value="Pistol" <%= (item.firearm_type === 'Pistol') ? 'selected' : '' %>>Pistol</option>
+        <option value="Shotgun" <%= (item.firearm_type === 'Shotgun') ? 'selected' : '' %>>Shotgun</option>
+        <option value="Revolver" <%= (item.firearm_type === 'Revolver') ? 'selected' : '' %>>Revolver</option>
+        <option value="Other" <%= (item.firearm_type === 'Other') ? 'selected' : '' %>>Other</option>
+      </select>
+      <small class="helper-text">Optional: Category used for filtering in inventory.</small>
+    </div>
+    <div class="col-span-2">
+      <label class="form-checkbox" for="gun_warranty">
+        <input id="gun_warranty" type="checkbox" name="gun_warranty" value="1" <%= (item.gun_warranty) ? 'checked' : '' %>>
+        <span>
+          Gun Warranty
+          <small class="helper-text">Check if the firearm is currently under manufacturer warranty.</small>
+        </span>
+      </label>
+    </div>
+  </div>
+</fieldset>
+
+<fieldset class="form-section disposition-section <%= (item.status === 'Sold' || item.status === 'Lost/Stolen') ? '' : 'hidden' %>">
+  <legend class="section-header label-caps">Disposition</legend>
   <div class="grid">
     <div>
       <label for="firearm-disposition-name">Transferred/Sold To</label>
@@ -86,29 +126,12 @@
       <input id="firearm-disposition-reason" name="disposition_reason" placeholder="e.g., Sold, Lost, Stolen, Transferred" value="<%= item.disposition_reason || '' %>">
     </div>
   </div>
-</div>
-<div>
-  <label for="firearm-firearm-type">Firearm Type</label>
-  <select id="firearm-firearm-type" name="firearm_type">
-    <option value="">Select...</option>
-    <option value="Rifle" <%= (item.firearm_type === 'Rifle') ? 'selected' : '' %>>Rifle</option>
-    <option value="Pistol" <%= (item.firearm_type === 'Pistol') ? 'selected' : '' %>>Pistol</option>
-    <option value="Shotgun" <%= (item.firearm_type === 'Shotgun') ? 'selected' : '' %>>Shotgun</option>
-    <option value="Revolver" <%= (item.firearm_type === 'Revolver') ? 'selected' : '' %>>Revolver</option>
-    <option value="Other" <%= (item.firearm_type === 'Other') ? 'selected' : '' %>>Other</option>
-  </select>
-  <small class="helper-text">Optional: Category used for filtering in inventory.</small>
-</div>
-<div>
-  <label class="form-checkbox" for="gun_warranty">
-    <input id="gun_warranty" type="checkbox" name="gun_warranty" value="1" <%= (item.gun_warranty) ? 'checked' : '' %>>
-    <span>
-      Gun Warranty
-      <small class="helper-text">Check if the firearm is currently under manufacturer warranty.</small>
-    </span>
-  </label>
-</div>
-<div class="col-span-2">
-  <label for="firearm-notes">Notes</label>
-  <textarea id="firearm-notes" name="notes" rows="4"><%= item.notes || '' %></textarea>
-</div>
+</fieldset>
+
+<fieldset class="form-section">
+  <legend class="section-header label-caps">Notes</legend>
+  <div>
+    <label for="firearm-notes">Notes</label>
+    <textarea id="firearm-notes" name="notes" rows="4"><%= item.notes || '' %></textarea>
+  </div>
+</fieldset>

--- a/src/views/firearms/edit-content.ejs
+++ b/src/views/firearms/edit-content.ejs
@@ -6,7 +6,7 @@
     <div class="alert alert-error"><%= error %></div>
   <% } %>
   <section class="card">
-    <form method="post" action="/firearms/<%= item.id %>?_method=PUT" class="form grid">
+    <form method="post" action="/firearms/<%= item.id %>?_method=PUT" class="form">
       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <%- include('./_form', { item, fieldErrors: fieldErrors || {} }) %>
       <div class="form-actions">

--- a/src/views/firearms/new-content.ejs
+++ b/src/views/firearms/new-content.ejs
@@ -6,7 +6,7 @@
     <div class="alert alert-error"><%= error %></div>
   <% } %>
   <section class="card">
-    <form method="post" action="/firearms" class="form grid">
+    <form method="post" action="/firearms" class="form">
       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <%- include('./_form', { item, fieldErrors: fieldErrors || {} }) %>
       <div class="form-actions">

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -83,7 +83,7 @@
 
     <section class="detail-card detail-card-full panel">
       <p class="section-header label-caps">Notes</p>
-      <pre class="notes mono"><%= item.notes || '-' %></pre>
+      <div class="notes"><%= item.notes || '-' %></div>
     </section>
   </div>
 


### PR DESCRIPTION
## Summary

Implements Epic #461 — Firearm Form & Detail polish across three sub-issues:

- **#434** — Wraps `_form.ejs` flat field list into `<fieldset>` sections (Profile, Purchase, Ownership, Disposition, Notes) mirroring the detail view layout. Each section uses `<legend class="section-header label-caps">` and an inner `.grid` for the two-column layout. Removes `.grid` from the `<form>` element in the wrapper views and adds `.form-section` CSS to reset fieldset browser defaults. The disposition JS toggle (`firearm-form.js`) is unaffected — it targets `.disposition-section` which is now on the fieldset.
- **#438** — Removes the dead `mono` class from the Notes element on the detail page and replaces `<pre>` with `<div class="notes">`. The `.notes` rule already sets `white-space: pre-wrap` and `font-family: var(--font-sans)`, so the rendering is unchanged but the markup no longer contradicts itself.
- **#456** — The accessible delete modal was already fully wired up in the existing codebase (HTML, ARIA attributes, JS focus management, Escape key, integration test). No code changes were needed; this PR closes the tracking issue.

## Test plan

- [ ] Add a new firearm — confirm the form renders with four labelled sections (Profile, Purchase, Ownership, Notes) separated by dividers
- [ ] Set Status to Sold or Lost/Stolen — confirm the Disposition section appears; change back — confirm it hides
- [ ] Edit an existing firearm — same section structure, existing values pre-filled
- [ ] View a firearm detail page — Notes block renders in sans-serif with no visual change
- [ ] Click Delete on the detail page — modal opens, Cancel dismisses, Delete submits the form; Escape also dismisses
- [ ] All 50 passing tests continue to pass (`npx jest --runInBand`)

Closes #434
Closes #438
Closes #456
Closes #461

---
_Generated by [Claude Code](https://claude.ai/code/session_012Vk6NYxAMtDhakZXT37fnc)_