### PR TITLE
feat: WCAG AA baseline and app shell polish (Epics #462 & #463)

### DIFF
--- a/src/features/auth/auth.controller.js
+++ b/src/features/auth/auth.controller.js
@@ -3,6 +3,7 @@ const { auditLog } = require('../../services/audit.service');
 function createAuthController(authService) {
   function createProfileViewModel(overrides = {}) {
     return {
+      pageTitle: 'Profile',
       usernameError: null,
       usernameSuccess: null,
       passwordError: null,
@@ -21,7 +22,7 @@ function createAuthController(authService) {
       if (req.session.user) {
         return res.redirect('/');
       }
-      return res.render('auth/login', { error: null });
+      return res.render('auth/login', { pageTitle: 'Login', error: null });
     },
 
     async login(req, res) {
@@ -30,7 +31,7 @@ function createAuthController(authService) {
 
       if (!valid) {
         auditLog('login.failure', { ip: req.ip, username });
-        return res.status(401).render('auth/login', { error: 'Invalid credentials' });
+        return res.status(401).render('auth/login', { pageTitle: 'Login', error: 'Invalid credentials' });
       }
 
       req.session.user = { username };
@@ -53,20 +54,20 @@ function createAuthController(authService) {
     },
 
     showChangePassword(req, res) {
-      return res.render('auth/change-password', { error: null });
+      return res.render('auth/change-password', { pageTitle: 'Change Password', error: null });
     },
 
     async changePassword(req, res) {
       const { current_password, new_password, confirm_password } = req.body;
 
       if (new_password !== confirm_password) {
-        return res.render('auth/change-password', { error: 'Passwords do not match.' });
+        return res.render('auth/change-password', { pageTitle: 'Change Password', error: 'Passwords do not match.' });
       }
 
       const result = await authService.changePassword(current_password, new_password);
 
       if (!result.success) {
-        return res.render('auth/change-password', { error: result.error });
+        return res.render('auth/change-password', { pageTitle: 'Change Password', error: result.error });
       }
 
       req.session.mustChangePassword = false;

--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -13,6 +13,7 @@ function createFirearmsController(firearmsService) {
       const { items } = firearmsService.paginate(page, perPage);
 
       res.render('firearms/index', {
+        pageTitle: 'Inventory',
         items,
         pagination: {
           currentPage: page,
@@ -37,7 +38,7 @@ function createFirearmsController(firearmsService) {
     },
 
     showNew(req, res) {
-      res.render('firearms/new', { item: {}, fieldErrors: {}, error: null });
+      res.render('firearms/new', { pageTitle: 'Add Firearm', item: {}, fieldErrors: {}, error: null });
     },
 
     create(req, res) {
@@ -46,6 +47,7 @@ function createFirearmsController(firearmsService) {
 
       if (!isValid) {
         return res.status(400).render('firearms/new', {
+          pageTitle: 'Add Firearm',
           item: data,
           fieldErrors,
           error: 'Please correct the highlighted fields and try again.'
@@ -63,7 +65,7 @@ function createFirearmsController(firearmsService) {
       if (!item) {
         return res.status(404).render('errors/404');
       }
-      return res.render('firearms/show', { item });
+      return res.render('firearms/show', { pageTitle: `${item.make} ${item.model}`, item });
     },
 
     duplicate(req, res) {
@@ -81,7 +83,7 @@ function createFirearmsController(firearmsService) {
       if (!item) {
         return res.status(404).render('errors/404');
       }
-      return res.render('firearms/edit', { item, fieldErrors: {}, error: null });
+      return res.render('firearms/edit', { pageTitle: `Edit ${item.make} ${item.model}`, item, fieldErrors: {}, error: null });
     },
 
     update(req, res) {
@@ -95,6 +97,7 @@ function createFirearmsController(firearmsService) {
 
       if (!isValid) {
         return res.status(400).render('firearms/edit', {
+          pageTitle: `Edit ${item.make} ${item.model}`,
           item: { ...item, ...data },
           fieldErrors,
           error: 'Please correct the highlighted fields and try again.'
@@ -119,7 +122,7 @@ function createFirearmsController(firearmsService) {
     },
 
     showImport(req, res) {
-      res.render('firearms/import', { results: null });
+      res.render('firearms/import', { pageTitle: 'Import Firearms', results: null });
     },
 
     downloadTemplate(req, res) {

--- a/src/features/home/home.controller.js
+++ b/src/features/home/home.controller.js
@@ -4,7 +4,7 @@ function createHomeController(homeService) {
       const username = req.session.user?.username || 'admin';
       const dashboard = homeService.getDashboard(username);
 
-      return res.render('home/index', dashboard);
+      return res.render('home/index', { ...dashboard, pageTitle: 'Dashboard' });
     }
   };
 }

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1161,6 +1161,36 @@ main:focus-visible {
   flex-wrap: wrap;
 }
 
+.error-hero {
+  text-align: center;
+}
+
+.error-glyph {
+  display: inline-flex;
+  width: 56px;
+  height: 56px;
+  border-radius: 999px;
+  background: var(--accent2-bg);
+  color: var(--accent2);
+  font-size: 28px;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+
+.error-glyph--blocked {
+  background: var(--status-repair-bg);
+  color: var(--status-repair-text);
+}
+
+.error-code {
+  margin: 0 0 4px;
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
 .card.login-card {
   animation: floatIn 0.35s ease;
 }
@@ -1974,5 +2004,37 @@ main:focus-visible {
 
   .home-chart-wrap canvas {
     height: 220px;
+  }
+}
+
+@media print {
+  .topbar,
+  .app-footer,
+  .item-toolbar,
+  .action-bar,
+  #delete-modal { display: none !important; }
+
+  body {
+    background: #fff !important;
+    color: #000 !important;
+  }
+
+  .card, .panel, .detail-card {
+    box-shadow: none !important;
+    border: 1px solid #999 !important;
+    background: #fff !important;
+    page-break-inside: avoid;
+  }
+
+  .badge {
+    border: 1px solid #999;
+    color: #000;
+    background: #fff;
+  }
+
+  a[href]::after {
+    content: ' (' attr(href) ')';
+    font-size: 11px;
+    color: #555;
   }
 }

--- a/src/public/js/search.js
+++ b/src/public/js/search.js
@@ -376,11 +376,31 @@
     }
   }
 
-  // Attach handlers to all clickable rows
-  const clickableRows = document.querySelectorAll('.table-row-clickable');
-  clickableRows.forEach((row) => {
+  // Attach handlers to all clickable rows with roving tabindex
+  const clickableRows = Array.from(document.querySelectorAll('.table-row-clickable'));
+
+  function updateRovingTabindex(focusedRow) {
+    clickableRows.forEach((row) => {
+      row.setAttribute('tabindex', row === focusedRow ? '0' : '-1');
+    });
+  }
+
+  clickableRows.forEach((row, i) => {
     row.addEventListener('click', handleRowClick);
-    row.addEventListener('keydown', handleRowKeydown);
+    row.addEventListener('focus', () => updateRovingTabindex(row));
+    row.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = clickableRows[Math.min(i + 1, clickableRows.length - 1)];
+        if (next) { updateRovingTabindex(next); next.focus(); }
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = clickableRows[Math.max(i - 1, 0)];
+        if (prev) { updateRovingTabindex(prev); prev.focus(); }
+      } else {
+        handleRowKeydown(e);
+      }
+    });
   });
 
   updateClearVisibility();

--- a/src/public/js/theme.js
+++ b/src/public/js/theme.js
@@ -45,30 +45,40 @@
     );
   }
   
+  async function toggleThemeRequest() {
+    const csrfToken = getCsrfToken();
+    if (!csrfToken) return null;
+    try {
+      const response = await fetch('/toggle-theme', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-csrf-token': csrfToken }
+      });
+      if (response.ok) {
+        const data = await response.json();
+        return data.theme;
+      }
+    } catch (error) {
+      console.error('Failed to toggle theme:', error);
+    }
+    return null;
+  }
+
   // Toggle theme on button click
   if (themeToggle) {
     themeToggle.addEventListener('click', async function() {
-      const csrfToken = getCsrfToken();
-      if (!csrfToken) {
-        console.error('CSRF token not found');
-        return;
-      }
-      
-      try {
-        const response = await fetch('/toggle-theme', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'x-csrf-token': csrfToken
-          }
-        });
-        
-        if (response.ok) {
-          const data = await response.json();
-          applyTheme(data.theme);
-        }
-      } catch (error) {
-        console.error('Failed to toggle theme:', error);
+      const newTheme = await toggleThemeRequest();
+      if (newTheme) applyTheme(newTheme);
+    });
+  }
+
+  // Live-preview theme select on profile page
+  const profileThemeSelect = document.getElementById('profile-theme');
+  if (profileThemeSelect) {
+    profileThemeSelect.addEventListener('change', async function() {
+      const selected = this.value;
+      if (selected !== getCurrentTheme()) {
+        const newTheme = await toggleThemeRequest();
+        if (newTheme) applyTheme(newTheme);
       }
     });
   }

--- a/src/views/auth/profile-content.ejs
+++ b/src/views/auth/profile-content.ejs
@@ -44,7 +44,7 @@
       <input type="hidden" name="_csrf" value="<%= csrfToken %>">
       <label>
         Theme
-        <select name="theme" required>
+        <select id="profile-theme" name="theme" required>
           <option value="dark" <%= themeValue === 'dark' ? 'selected' : '' %>>Dark</option>
           <option value="light" <%= themeValue === 'light' ? 'selected' : '' %>>Light</option>
         </select>

--- a/src/views/errors/403-content.ejs
+++ b/src/views/errors/403-content.ejs
@@ -1,4 +1,6 @@
-<section class="app-hero">
+<section class="app-hero error-hero">
+  <span class="error-glyph error-glyph--blocked" aria-hidden="true">&#x1F6AB;</span>
+  <p class="label-caps error-code">Error 403</p>
   <h2 class="page-title">Request Blocked</h2>
   <p class="page-subtitle">Your session could not be verified. This usually means your login form expired or your browser dropped a security cookie.</p>
 </section>

--- a/src/views/errors/404-content.ejs
+++ b/src/views/errors/404-content.ejs
@@ -1,5 +1,7 @@
-<section class="app-hero">
-  <h2 class="page-title">Not Found</h2>
+<section class="app-hero error-hero">
+  <span class="error-glyph" aria-hidden="true">&#x26A0;</span>
+  <p class="label-caps error-code">Error 404</p>
+  <h2 class="page-title">Page Not Found</h2>
   <p class="page-subtitle">The page you requested could not be located.</p>
 </section>
 

--- a/src/views/firearms/_form.ejs
+++ b/src/views/firearms/_form.ejs
@@ -1,39 +1,55 @@
 <div>
   <label for="firearm-make">Make <span class="required-marker">*</span></label>
-  <input id="firearm-make" name="make" required aria-required="true" aria-invalid="<%= fieldErrors && fieldErrors.make ? 'true' : 'false' %>" value="<%= item.make || '' %>">
+  <input id="firearm-make" name="make" required aria-required="true"
+    aria-invalid="<%= fieldErrors && fieldErrors.make ? 'true' : 'false' %>"
+    <%= fieldErrors && fieldErrors.make ? 'aria-describedby="make-error"' : '' %>
+    value="<%= item.make || '' %>">
   <% if (fieldErrors && fieldErrors.make) { %>
-    <small class="field-error"><%= fieldErrors.make %></small>
+    <small id="make-error" class="field-error"><%= fieldErrors.make %></small>
   <% } %>
 </div>
 <div>
   <label for="firearm-model">Model <span class="required-marker">*</span></label>
-  <input id="firearm-model" name="model" required aria-required="true" aria-invalid="<%= fieldErrors && fieldErrors.model ? 'true' : 'false' %>" value="<%= item.model || '' %>">
+  <input id="firearm-model" name="model" required aria-required="true"
+    aria-invalid="<%= fieldErrors && fieldErrors.model ? 'true' : 'false' %>"
+    <%= fieldErrors && fieldErrors.model ? 'aria-describedby="model-error"' : '' %>
+    value="<%= item.model || '' %>">
   <% if (fieldErrors && fieldErrors.model) { %>
-    <small class="field-error"><%= fieldErrors.model %></small>
+    <small id="model-error" class="field-error"><%= fieldErrors.model %></small>
   <% } %>
 </div>
 <div>
   <label for="firearm-serial">Serial</label>
-  <input id="firearm-serial" name="serial" placeholder="e.g., ABC123456" value="<%= item.serial || '' %>">
-  <small class="helper-text">Optional: Enter the firearm's serial number</small>
+  <input id="firearm-serial" name="serial" placeholder="e.g., ABC123456"
+    aria-describedby="serial-help"
+    value="<%= item.serial || '' %>">
+  <small id="serial-help" class="helper-text">Optional: Enter the firearm's serial number</small>
 </div>
 <div>
   <label for="firearm-caliber">Caliber</label>
-  <input id="firearm-caliber" name="caliber" placeholder="e.g., 9mm, .45 ACP, 12 gauge" value="<%= item.caliber || '' %>">
-  <small class="helper-text">Optional: Enter caliber or gauge</small>
+  <input id="firearm-caliber" name="caliber" placeholder="e.g., 9mm, .45 ACP, 12 gauge"
+    aria-describedby="caliber-help"
+    value="<%= item.caliber || '' %>">
+  <small id="caliber-help" class="helper-text">Optional: Enter caliber or gauge</small>
 </div>
 <div>
   <label for="firearm-purchase-date">Purchase Date</label>
-  <input id="firearm-purchase-date" type="date" name="purchase_date" value="<%= item.purchase_date || '' %>">
-  <small class="helper-text">Select purchase date using the calendar picker</small>
+  <input id="firearm-purchase-date" type="date" name="purchase_date"
+    aria-describedby="purchase-date-help"
+    value="<%= item.purchase_date || '' %>">
+  <small id="purchase-date-help" class="helper-text">Select purchase date using the calendar picker</small>
 </div>
 <div>
   <label for="firearm-purchase-price">Purchase Price</label>
-  <input id="firearm-purchase-price" type="number" step="0.01" min="0" name="purchase_price" placeholder="0.00" value="<%= item.purchase_price ?? '' %>" aria-invalid="<%= fieldErrors && fieldErrors.purchase_price ? 'true' : 'false' %>">
+  <input id="firearm-purchase-price" type="number" step="0.01" min="0" name="purchase_price"
+    placeholder="0.00"
+    value="<%= item.purchase_price ?? '' %>"
+    aria-invalid="<%= fieldErrors && fieldErrors.purchase_price ? 'true' : 'false' %>"
+    aria-describedby="purchase-price-help<%= fieldErrors && fieldErrors.purchase_price ? ' purchase-price-error' : '' %>">
   <% if (fieldErrors && fieldErrors.purchase_price) { %>
-    <small class="field-error"><%= fieldErrors.purchase_price %></small>
+    <small id="purchase-price-error" class="field-error"><%= fieldErrors.purchase_price %></small>
   <% } %>
-  <small class="helper-text">Enter price in USD (e.g., 599.99)</small>
+  <small id="purchase-price-help" class="helper-text">Enter price in USD (e.g., 599.99)</small>
 </div>
 <div>
   <label for="firearm-condition">Purchase Condition</label>
@@ -46,12 +62,14 @@
 </div>
 <div>
   <label for="firearm-location">Location</label>
-  <input id="firearm-location" name="location" value="<%= item.location || '' %>">
-  <small class="helper-text">Optional: Storage location or range bag.</small>
+  <input id="firearm-location" name="location"
+    aria-describedby="location-help"
+    value="<%= item.location || '' %>">
+  <small id="location-help" class="helper-text">Optional: Storage location or range bag.</small>
 </div>
 <div>
   <label for="firearm-status">Status</label>
-  <select id="firearm-status" name="status">
+  <select id="firearm-status" name="status" aria-describedby="status-help">
     <option value="">Select...</option>
     <option value="Active" <%= (item.status === 'Active') ? 'selected' : '' %>>Active</option>
     <option value="In Transit" <%= (item.status === 'In Transit') ? 'selected' : '' %>>In Transit</option>
@@ -59,15 +77,18 @@
     <option value="Lost/Stolen" <%= (item.status === 'Lost/Stolen') ? 'selected' : '' %>>Lost/Stolen</option>
     <option value="Under Repair" <%= (item.status === 'Under Repair') ? 'selected' : '' %>>Under Repair</option>
   </select>
-  <small class="helper-text">Current ownership or maintenance state.</small>
+  <small id="status-help" class="helper-text">Current ownership or maintenance state.</small>
 </div>
 <div class="col-span-2 disposition-section <%= (item.status === 'Sold' || item.status === 'Lost/Stolen') ? '' : 'hidden' %>">
   <div class="grid">
     <div>
       <label for="firearm-disposition-name">Transferred/Sold To</label>
-      <input id="firearm-disposition-name" name="disposition_name" value="<%= item.disposition_name || '' %>" aria-invalid="<%= fieldErrors && fieldErrors.disposition_name ? 'true' : 'false' %>">
+      <input id="firearm-disposition-name" name="disposition_name"
+        value="<%= item.disposition_name || '' %>"
+        aria-invalid="<%= fieldErrors && fieldErrors.disposition_name ? 'true' : 'false' %>"
+        <%= fieldErrors && fieldErrors.disposition_name ? 'aria-describedby="disposition-name-error"' : '' %>>
       <% if (fieldErrors && fieldErrors.disposition_name) { %>
-        <small class="field-error"><%= fieldErrors.disposition_name %></small>
+        <small id="disposition-name-error" class="field-error"><%= fieldErrors.disposition_name %></small>
       <% } %>
     </div>
     <div>
@@ -76,9 +97,12 @@
     </div>
     <div>
       <label for="firearm-disposition-date">Date of Transfer</label>
-      <input id="firearm-disposition-date" type="date" name="disposition_date" value="<%= item.disposition_date || '' %>" aria-invalid="<%= fieldErrors && fieldErrors.disposition_date ? 'true' : 'false' %>">
+      <input id="firearm-disposition-date" type="date" name="disposition_date"
+        value="<%= item.disposition_date || '' %>"
+        aria-invalid="<%= fieldErrors && fieldErrors.disposition_date ? 'true' : 'false' %>"
+        <%= fieldErrors && fieldErrors.disposition_date ? 'aria-describedby="disposition-date-error"' : '' %>>
       <% if (fieldErrors && fieldErrors.disposition_date) { %>
-        <small class="field-error"><%= fieldErrors.disposition_date %></small>
+        <small id="disposition-date-error" class="field-error"><%= fieldErrors.disposition_date %></small>
       <% } %>
     </div>
     <div>
@@ -89,7 +113,7 @@
 </div>
 <div>
   <label for="firearm-firearm-type">Firearm Type</label>
-  <select id="firearm-firearm-type" name="firearm_type">
+  <select id="firearm-firearm-type" name="firearm_type" aria-describedby="firearm-type-help">
     <option value="">Select...</option>
     <option value="Rifle" <%= (item.firearm_type === 'Rifle') ? 'selected' : '' %>>Rifle</option>
     <option value="Pistol" <%= (item.firearm_type === 'Pistol') ? 'selected' : '' %>>Pistol</option>
@@ -97,14 +121,16 @@
     <option value="Revolver" <%= (item.firearm_type === 'Revolver') ? 'selected' : '' %>>Revolver</option>
     <option value="Other" <%= (item.firearm_type === 'Other') ? 'selected' : '' %>>Other</option>
   </select>
-  <small class="helper-text">Optional: Category used for filtering in inventory.</small>
+  <small id="firearm-type-help" class="helper-text">Optional: Category used for filtering in inventory.</small>
 </div>
 <div>
   <label class="form-checkbox" for="gun_warranty">
-    <input id="gun_warranty" type="checkbox" name="gun_warranty" value="1" <%= (item.gun_warranty) ? 'checked' : '' %>>
+    <input id="gun_warranty" type="checkbox" name="gun_warranty" value="1"
+      aria-describedby="gun-warranty-help"
+      <%= (item.gun_warranty) ? 'checked' : '' %>>
     <span>
       Gun Warranty
-      <small class="helper-text">Check if the firearm is currently under manufacturer warranty.</small>
+      <small id="gun-warranty-help" class="helper-text">Check if the firearm is currently under manufacturer warranty.</small>
     </span>
   </label>
 </div>

--- a/src/views/firearms/index-content.ejs
+++ b/src/views/firearms/index-content.ejs
@@ -168,7 +168,7 @@
           </tr>
         </thead>
         <tbody id="firearms-tbody">
-        <% items.forEach(i => { %>
+        <% items.forEach((i, rowIdx) => { %>
           <tr
             class="table-row-clickable"
             data-firearm-id="<%= i.id %>"
@@ -180,8 +180,8 @@
             data-condition="<%= i.condition || '' %>"
             data-firearm_type="<%= i.firearm_type || '' %>"
             data-purchase_date="<%= i.purchase_date || '' %>"
-            tabindex="0"
-            role="button"
+            tabindex="<%= rowIdx === 0 ? '0' : '-1' %>"
+            role="row"
             aria-label="View details for <%= i.make %> <%= i.model %>"
           >
             <td data-label="Make"><%= i.make %></td>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements all sub-tasks for Epic #462 (Accessibility) and Epic #463 (App Shell & Navigation).

### Epic #462 — Accessibility
- **#437** — Added stable `id` attributes to every `<small class="helper-text">` and `<small class="field-error">` in `_form.ejs`, and wired `aria-describedby` on each input/select so screen readers announce helper and error text at field focus.
- **#406** — Replaced `tabindex="0"` on every inventory table row with a roving tabindex pattern: first visible row is `0`, all others are `-1`. Arrow Up/Down moves focus between rows without adding every row to the tab order.

### Epic #463 — App Shell & Navigation
- **#457** — Each controller render call now passes `pageTitle`; the layout already renders `<Page> — Pew Pew Collection`. Pages covered: Dashboard, Inventory, Add Firearm, Edit Firearm, Firearm detail, Import, Profile, Login, Change Password.
- **#439** — 404 and 403 error pages now display a circular icon glyph (⚠ for 404, 🚫 for 403) using existing CSS token variables (`--accent2-bg`/`--accent2` and `--status-repair-bg`/`--status-repair-text`). New `.error-glyph` and `.error-hero` CSS classes added.
- **#440** — Profile theme `<select>` now has `id="profile-theme"`. `theme.js` binds a `change` listener that calls `/toggle-theme` immediately when the selected value differs from the current document theme, giving instant live preview before form submission.
- **#436** — Added `@media print` block to `styles.css` hiding topbar, footer, action bar and delete modal; forces white background and black text; strips box-shadows from cards; appends href text to links.

## Test plan
- [ ] All 141 existing tests pass (`npm test`)
- [ ] ESLint clean (`npm run lint`)
- [ ] Screen reader: focus any form field with helper text — confirm text is announced
- [ ] Screen reader: form field with validation error — confirm error text is announced
- [ ] Keyboard: Tab into inventory table — only one row is in tab order; arrow keys move between rows
- [ ] Each page has a unique browser tab title in `<Page> — Pew Pew Collection` format
- [ ] Navigate to `/nonexistent` — 404 page shows warning glyph and "Error 404" label
- [ ] Trigger a CSRF error — 403 page shows blocked glyph and "Error 403" label
- [ ] Profile page: change theme select without saving — theme switches instantly
- [ ] Open firearm detail page and print preview — topbar/footer/buttons hidden, white background

https://claude.ai/code/session_01KAapd85Ru7epUKuf6cNBzT
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAapd85Ru7epUKuf6cNBzT)_