### PR TITLE
feat(reports): reporting & analytics dashboard (#458)

### DIFF
--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -25,6 +25,10 @@ const { createFirearmsRoutes } = require('../features/firearms/firearms.routes')
 const { createHomeService } = require('../features/home/home.service');
 const { createHomeController } = require('../features/home/home.controller');
 const { createHomeRoutes } = require('../features/home/home.routes');
+const { createReportsRepository } = require('../infra/db/repositories/reports.repository');
+const { createReportsService } = require('../features/reports/reports.service');
+const { createReportsController } = require('../features/reports/reports.controller');
+const { createReportsRoutes } = require('../features/reports/reports.routes');
 
 async function createApp(options = {}) {
   const config = options.config || getConfig();
@@ -64,6 +68,9 @@ async function createApp(options = {}) {
   const firearmsController = createFirearmsController(firearmsService);
   const homeService = createHomeService(firearmsRepository);
   const homeController = createHomeController(homeService);
+  const reportsRepository = createReportsRepository(db);
+  const reportsService = createReportsService(reportsRepository);
+  const reportsController = createReportsController(reportsService);
 
   const app = express();
 
@@ -208,7 +215,8 @@ async function createApp(options = {}) {
   registerRoutes(app, {
     authRoutes: createAuthRoutes(authController),
     homeRoutes: createHomeRoutes(homeController),
-    firearmsRoutes: createFirearmsRoutes(firearmsController)
+    firearmsRoutes: createFirearmsRoutes(firearmsController),
+    reportsRoutes: createReportsRoutes(reportsController)
   });
 
   app.use((req, res) => {

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -1,7 +1,8 @@
-function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes }) {
+function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes, reportsRoutes }) {
   app.use('/', authRoutes);
   app.use('/', homeRoutes);
   app.use('/firearms', firearmsRoutes);
+  app.use('/', reportsRoutes);
 }
 
 module.exports = { registerRoutes };

--- a/src/features/reports/reports.controller.js
+++ b/src/features/reports/reports.controller.js
@@ -1,0 +1,10 @@
+function createReportsController(reportsService) {
+  return {
+    index(req, res) {
+      const data = reportsService.getReports();
+      return res.render('reports/index', data);
+    }
+  };
+}
+
+module.exports = { createReportsController };

--- a/src/features/reports/reports.routes.js
+++ b/src/features/reports/reports.routes.js
@@ -1,0 +1,12 @@
+const { Router } = require('express');
+const { requireAuth } = require('../../app/middleware/auth');
+
+function createReportsRoutes(reportsController) {
+  const router = Router();
+
+  router.get('/reports', requireAuth, reportsController.index);
+
+  return router;
+}
+
+module.exports = { createReportsRoutes };

--- a/src/features/reports/reports.service.js
+++ b/src/features/reports/reports.service.js
@@ -1,0 +1,44 @@
+function createReportsService(reportsRepository) {
+  return {
+    getReports() {
+      const summary = reportsRepository.getCollectionSummary();
+      const byType = reportsRepository.getBreakdownByType();
+      const byCaliber = reportsRepository.getBreakdownByCaliber();
+      const byMake = reportsRepository.getBreakdownByMake();
+      const acquisitionByMonth = reportsRepository.getAcquisitionByMonth();
+      const avgPriceByYear = reportsRepository.getAvgPriceByYear();
+      const disposition = reportsRepository.getDispositionStats();
+      const byCondition = reportsRepository.getConditionBreakdown();
+
+      return {
+        summary: {
+          totalFirearms: summary.total_firearms || 0,
+          totalValue: summary.total_value || 0,
+          activeCount: summary.active_count || 0,
+          activeValue: summary.active_value || 0,
+          soldCount: summary.sold_count || 0,
+          soldValue: summary.sold_value || 0,
+          lostCount: summary.lost_count || 0,
+          repairCount: summary.repair_count || 0,
+          transitCount: summary.transit_count || 0
+        },
+        charts: {
+          byType,
+          byCaliber,
+          byMake,
+          acquisitionByMonth,
+          avgPriceByYear,
+          byCondition
+        },
+        disposition: {
+          disposedCount: disposition.disposed_count || 0,
+          totalProceeds: disposition.total_proceeds || 0,
+          avgHoldDays: disposition.avg_hold_days
+        },
+        isEmpty: (summary.total_firearms || 0) === 0
+      };
+    }
+  };
+}
+
+module.exports = { createReportsService };

--- a/src/infra/db/repositories/reports.repository.js
+++ b/src/infra/db/repositories/reports.repository.js
@@ -1,0 +1,114 @@
+function createReportsRepository(db) {
+  return {
+    getCollectionSummary() {
+      return db.prepare(`
+        SELECT
+          COUNT(*) AS total_firearms,
+          ROUND(SUM(CASE WHEN purchase_price IS NOT NULL THEN purchase_price ELSE 0 END), 2) AS total_value,
+          ROUND(SUM(CASE WHEN status = 'Active' AND purchase_price IS NOT NULL THEN purchase_price ELSE 0 END), 2) AS active_value,
+          ROUND(SUM(CASE WHEN status = 'Sold' AND purchase_price IS NOT NULL THEN purchase_price ELSE 0 END), 2) AS sold_value,
+          COUNT(CASE WHEN status = 'Active' THEN 1 END) AS active_count,
+          COUNT(CASE WHEN status = 'Sold' THEN 1 END) AS sold_count,
+          COUNT(CASE WHEN status = 'Lost' THEN 1 END) AS lost_count,
+          COUNT(CASE WHEN status = 'In Repair' THEN 1 END) AS repair_count,
+          COUNT(CASE WHEN status = 'In Transit' THEN 1 END) AS transit_count
+        FROM firearms
+      `).get();
+    },
+
+    getBreakdownByType() {
+      return db.prepare(`
+        SELECT
+          COALESCE(NULLIF(TRIM(firearm_type), ''), 'Unknown') AS label,
+          COUNT(*) AS count
+        FROM firearms
+        GROUP BY label
+        ORDER BY count DESC, label ASC
+      `).all();
+    },
+
+    getBreakdownByCaliber() {
+      return db.prepare(`
+        SELECT
+          COALESCE(NULLIF(TRIM(caliber), ''), 'Unknown') AS label,
+          COUNT(*) AS count
+        FROM firearms
+        GROUP BY label
+        ORDER BY count DESC, label ASC
+        LIMIT 15
+      `).all();
+    },
+
+    getBreakdownByMake() {
+      return db.prepare(`
+        SELECT
+          COALESCE(NULLIF(TRIM(make), ''), 'Unknown') AS label,
+          COUNT(*) AS count
+        FROM firearms
+        GROUP BY label
+        ORDER BY count DESC, label ASC
+        LIMIT 15
+      `).all();
+    },
+
+    getAcquisitionByMonth() {
+      return db.prepare(`
+        SELECT
+          strftime('%Y-%m', purchase_date) AS month,
+          COUNT(*) AS count
+        FROM firearms
+        WHERE purchase_date IS NOT NULL
+          AND TRIM(purchase_date) != ''
+        GROUP BY month
+        ORDER BY month ASC
+      `).all();
+    },
+
+    getAvgPriceByYear() {
+      return db.prepare(`
+        SELECT
+          strftime('%Y', purchase_date) AS year,
+          ROUND(AVG(purchase_price), 2) AS avg_price,
+          COUNT(*) AS count
+        FROM firearms
+        WHERE purchase_date IS NOT NULL
+          AND TRIM(purchase_date) != ''
+          AND purchase_price IS NOT NULL
+        GROUP BY year
+        ORDER BY year ASC
+      `).all();
+    },
+
+    getDispositionStats() {
+      return db.prepare(`
+        SELECT
+          COUNT(*) AS disposed_count,
+          ROUND(SUM(CASE WHEN purchase_price IS NOT NULL THEN purchase_price ELSE 0 END), 2) AS total_proceeds,
+          ROUND(AVG(
+            CASE
+              WHEN disposition_date IS NOT NULL
+                AND TRIM(disposition_date) != ''
+                AND purchase_date IS NOT NULL
+                AND TRIM(purchase_date) != ''
+              THEN julianday(disposition_date) - julianday(purchase_date)
+            END
+          ), 1) AS avg_hold_days
+        FROM firearms
+        WHERE status IN ('Sold', 'Transferred')
+      `).get();
+    },
+
+    getConditionBreakdown() {
+      return db.prepare(`
+        SELECT
+          COALESCE(NULLIF(TRIM(condition), ''), 'Unknown') AS label,
+          COUNT(*) AS count
+        FROM firearms
+        GROUP BY label
+        ORDER BY count DESC, label ASC
+      `).all();
+    }
+  };
+}
+
+module.exports = { createReportsRepository };

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1736,6 +1736,142 @@ main:focus-visible {
   margin-bottom: 0.25rem;
 }
 
+/* ── Reports page ───────────────────────────────────────────── */
+
+.reports-hero {
+  padding: 2rem 0 1.5rem;
+}
+
+.reports-hero-tag {
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+
+.reports-hero-title {
+  margin: 0 0 0.5rem;
+}
+
+.reports-hero-subtitle {
+  margin: 0 0 1.5rem;
+  color: var(--text-muted);
+}
+
+.reports-section-title {
+  color: var(--text-muted);
+  margin: 2rem 0 1rem;
+  font-size: 11px;
+}
+
+.reports-stat-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-bottom: 1rem;
+}
+
+.reports-stat {
+  flex: 1 1 160px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 1.25rem 1.5rem;
+}
+
+.reports-stat-value {
+  font-size: 2rem;
+  font-weight: 600;
+  color: var(--text-strong);
+  line-height: 1;
+}
+
+.reports-stat-label {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.reports-status-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 2rem;
+}
+
+.reports-status-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.reports-chart-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.reports-card-header {
+  padding: 1.25rem 1.5rem 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.reports-card-header p {
+  margin: 0 0 0.25rem;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.reports-card-header h3 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.reports-card-body {
+  padding: 1.25rem 1.5rem;
+}
+
+.reports-chart-card-body {
+  padding: 1rem 1.25rem;
+}
+
+.reports-chart-wrap {
+  position: relative;
+  min-height: 260px;
+}
+
+.reports-chart-wrap canvas {
+  display: block;
+  height: 260px;
+}
+
+.reports-chart-empty {
+  margin: 6px 0 0;
+}
+
+.reports-disposition {
+  margin-bottom: 2rem;
+}
+
+.reports-empty {
+  display: flex;
+  justify-content: center;
+  padding: 3rem 0;
+}
+
+.reports-empty-card {
+  text-align: center;
+  padding: 2.5rem 3rem;
+  max-width: 480px;
+}
+
+.reports-empty-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text-strong);
+  margin: 0 0 0.5rem;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -1974,5 +2110,33 @@ main:focus-visible {
 
   .home-chart-wrap canvas {
     height: 220px;
+  }
+
+  .reports-hero {
+    padding: 0;
+  }
+
+  .reports-stat-grid {
+    gap: 10px;
+  }
+
+  .reports-stat {
+    min-width: calc(50% - 5px);
+  }
+
+  .reports-chart-row {
+    grid-template-columns: 1fr;
+  }
+
+  .reports-chart-wrap {
+    min-height: 220px;
+  }
+
+  .reports-chart-wrap canvas {
+    height: 220px;
+  }
+
+  .reports-status-grid {
+    flex-direction: column;
   }
 }

--- a/src/public/js/reports-charts.js
+++ b/src/public/js/reports-charts.js
@@ -1,0 +1,173 @@
+(function() {
+  const chartDataScript = document.getElementById('reports-charts-data');
+  if (!chartDataScript || typeof Chart === 'undefined') {
+    return;
+  }
+
+  function safeParseData() {
+    try {
+      return JSON.parse(chartDataScript.textContent || '{}');
+    } catch (error) {
+      console.error('Failed to parse reports chart data', error);
+      return {};
+    }
+  }
+
+  function getCssVar(name, fallback) {
+    const value = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return value || fallback;
+  }
+
+  function formatCurrency(value) {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(value);
+  }
+
+  const palette = ['#1f4b5f', '#c2894f', '#4f7a8d', '#7b5a3a', '#8ca7b3', '#5f3f1f', '#3f5f4f', '#7a4f6e', '#4f6e7a', '#6e7a4f'];
+  const parsedData = safeParseData();
+
+  const charts = [];
+
+  function chartFont() {
+    return { canvas: "12px 'DM Sans', system-ui, sans-serif" };
+  }
+
+  function buildDoughnutChart(canvasId, data, labelKey) {
+    const canvas = document.getElementById(canvasId);
+    if (!(canvas && data && data.length)) return null;
+
+    const textColor = getCssVar('--text', '#eef1f5');
+    const borderColor = getCssVar('--border', '#233141');
+
+    return new Chart(canvas, {
+      type: 'doughnut',
+      data: {
+        labels: data.map((item) => `${item[labelKey]} (${item.count})`),
+        datasets: [{
+          data: data.map((item) => item.count),
+          backgroundColor: data.map((_, i) => palette[i % palette.length]),
+          borderColor,
+          borderWidth: 1
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        font: chartFont(),
+        plugins: {
+          legend: {
+            position: 'bottom',
+            labels: {
+              color: textColor,
+              boxWidth: 14,
+              padding: 14
+            }
+          },
+          tooltip: {
+            callbacks: {
+              label(context) {
+                return `${context.label}: ${context.parsed}`;
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  function buildBarChart(canvasId, data, labelKey, valueKey, valueFormatter) {
+    const canvas = document.getElementById(canvasId);
+    if (!(canvas && data && data.length)) return null;
+
+    const textColor = getCssVar('--text', '#eef1f5');
+    const gridColor = getCssVar('--border', '#233141');
+    const accentColor = getCssVar('--accent', '#1f4b5f');
+
+    return new Chart(canvas, {
+      type: 'bar',
+      data: {
+        labels: data.map((item) => item[labelKey]),
+        datasets: [{
+          label: valueFormatter ? 'Value' : 'Count',
+          data: data.map((item) => Number(item[valueKey])),
+          backgroundColor: accentColor,
+          borderRadius: 6,
+          maxBarThickness: 48
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        font: chartFont(),
+        scales: {
+          x: {
+            ticks: { color: textColor, maxRotation: 45 },
+            grid: { color: gridColor }
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              color: textColor,
+              callback(value) {
+                return valueFormatter ? valueFormatter(value) : value;
+              }
+            },
+            grid: { color: gridColor }
+          }
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            callbacks: {
+              label(context) {
+                const val = context.parsed.y;
+                return valueFormatter ? valueFormatter(val) : val;
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+
+  function renderCharts() {
+    charts.forEach((c) => c.destroy());
+    charts.length = 0;
+
+    const typeData = Array.isArray(parsedData.byType) ? parsedData.byType : [];
+    const caliberData = Array.isArray(parsedData.byCaliber) ? parsedData.byCaliber : [];
+    const makeData = Array.isArray(parsedData.byMake) ? parsedData.byMake : [];
+    const acquisitionData = Array.isArray(parsedData.acquisitionByMonth) ? parsedData.acquisitionByMonth : [];
+    const avgPriceData = Array.isArray(parsedData.avgPriceByYear) ? parsedData.avgPriceByYear : [];
+    const conditionData = Array.isArray(parsedData.byCondition) ? parsedData.byCondition : [];
+
+    const typeChart = buildDoughnutChart('reports-type-chart', typeData, 'label');
+    if (typeChart) charts.push(typeChart);
+
+    const caliberChart = buildBarChart('reports-caliber-chart', caliberData, 'label', 'count', null);
+    if (caliberChart) charts.push(caliberChart);
+
+    const acquisitionChart = buildBarChart('reports-acquisition-chart', acquisitionData, 'month', 'count', null);
+    if (acquisitionChart) charts.push(acquisitionChart);
+
+    const avgPriceChart = buildBarChart('reports-avgprice-chart', avgPriceData, 'year', 'avg_price', formatCurrency);
+    if (avgPriceChart) charts.push(avgPriceChart);
+
+    const conditionChart = buildDoughnutChart('reports-condition-chart', conditionData, 'label');
+    if (conditionChart) charts.push(conditionChart);
+
+    const makeChart = buildBarChart('reports-make-chart', makeData, 'label', 'count', null);
+    if (makeChart) charts.push(makeChart);
+  }
+
+  renderCharts();
+
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type === 'attributes' && mutation.attributeName === 'data-theme') {
+        renderCharts();
+        break;
+      }
+    }
+  });
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+})();

--- a/src/views/partials/layout.ejs
+++ b/src/views/partials/layout.ejs
@@ -34,6 +34,7 @@
   <% const isHome = currentPath === '/' || currentPath === '/home'; %>
   <% const isInventory = currentPath && currentPath.startsWith('/firearms') && !currentPath.startsWith('/firearms/new'); %>
   <% const isAddFirearm = currentPath === '/firearms/new'; %>
+  <% const isReports = currentPath && currentPath.startsWith('/reports'); %>
   <% const isProfile = currentPath && currentPath.startsWith('/profile'); %>
   <header class="topbar">
     <div class="container">
@@ -55,6 +56,11 @@
             href="/firearms/new"
             <%= isAddFirearm ? 'aria-current="page"' : '' %>
           >Add Firearm</a>
+          <a
+            class="nav-link <%= isReports ? 'active' : '' %>"
+            href="/reports"
+            <%= isReports ? 'aria-current="page"' : '' %>
+          >Reports</a>
           <a
             class="nav-link <%= isProfile ? 'active' : '' %>"
             href="/profile"

--- a/src/views/reports/index-content.ejs
+++ b/src/views/reports/index-content.ejs
@@ -1,0 +1,195 @@
+<section class="app-hero reports-hero" aria-label="Reports overview">
+  <p class="reports-hero-tag label-caps">Analytics</p>
+  <h2 class="reports-hero-title page-title">Reports</h2>
+  <p class="reports-hero-subtitle meta">Insights into your collection — all computed locally from your data.</p>
+</section>
+
+<% if (isEmpty) { %>
+<section class="reports-empty" aria-label="Empty collection notice">
+  <article class="card panel reports-empty-card">
+    <p class="reports-empty-title">No data yet</p>
+    <p class="meta">Add firearms to your inventory to see analytics and insights here.</p>
+    <a class="btn btn-primary" href="/firearms/new">Add your first firearm</a>
+  </article>
+</section>
+<% } else { %>
+
+<section class="reports-summary" aria-label="Collection summary">
+  <h3 class="reports-section-title label-caps">Collection Summary</h3>
+  <div class="reports-stat-grid" role="list" aria-label="Collection statistics">
+    <div class="reports-stat stat-card" role="listitem">
+      <span class="reports-stat-value stat-value mono"><%= summary.totalFirearms %></span>
+      <span class="reports-stat-label stat-label label-caps">Total Firearms</span>
+    </div>
+    <div class="reports-stat stat-card" role="listitem">
+      <span class="reports-stat-value stat-value mono">
+        $<%= summary.totalValue.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }) %>
+      </span>
+      <span class="reports-stat-label stat-label label-caps">Total Value</span>
+    </div>
+    <div class="reports-stat stat-card" role="listitem">
+      <span class="reports-stat-value stat-value mono"><%= summary.activeCount %></span>
+      <span class="reports-stat-label stat-label label-caps">Active</span>
+    </div>
+    <div class="reports-stat stat-card" role="listitem">
+      <span class="reports-stat-value stat-value mono">
+        $<%= summary.activeValue.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }) %>
+      </span>
+      <span class="reports-stat-label stat-label label-caps">Active Value</span>
+    </div>
+  </div>
+
+  <div class="reports-status-grid" role="list" aria-label="Status breakdown">
+    <div class="reports-status-item" role="listitem">
+      <span class="status-badge status-sold"><%= summary.soldCount %> Sold</span>
+      <% if (summary.soldValue > 0) { %>
+        <span class="meta">
+          $<%= summary.soldValue.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }) %>
+        </span>
+      <% } %>
+    </div>
+    <% if (summary.lostCount > 0) { %>
+    <div class="reports-status-item" role="listitem">
+      <span class="status-badge status-lost"><%= summary.lostCount %> Lost</span>
+    </div>
+    <% } %>
+    <% if (summary.repairCount > 0) { %>
+    <div class="reports-status-item" role="listitem">
+      <span class="status-badge status-repair"><%= summary.repairCount %> In Repair</span>
+    </div>
+    <% } %>
+    <% if (summary.transitCount > 0) { %>
+    <div class="reports-status-item" role="listitem">
+      <span class="status-badge status-transit"><%= summary.transitCount %> In Transit</span>
+    </div>
+    <% } %>
+  </div>
+</section>
+
+<section class="reports-chart-row" aria-label="Breakdown charts">
+  <article class="card panel">
+    <header class="reports-card-header">
+      <p class="label-caps">Breakdown</p>
+      <h3>By Firearm Type</h3>
+    </header>
+    <div class="reports-card-body reports-chart-card-body">
+      <% if (!charts.byType.length) { %>
+        <p class="muted-text reports-chart-empty meta">No firearm type data available.</p>
+      <% } else { %>
+        <div class="reports-chart-wrap">
+          <canvas id="reports-type-chart" aria-label="Collection by firearm type" role="img"></canvas>
+        </div>
+      <% } %>
+    </div>
+  </article>
+
+  <article class="card panel">
+    <header class="reports-card-header">
+      <p class="label-caps">Breakdown</p>
+      <h3>By Caliber</h3>
+    </header>
+    <div class="reports-card-body reports-chart-card-body">
+      <% if (!charts.byCaliber.length) { %>
+        <p class="muted-text reports-chart-empty meta">No caliber data available.</p>
+      <% } else { %>
+        <div class="reports-chart-wrap">
+          <canvas id="reports-caliber-chart" aria-label="Collection by caliber" role="img"></canvas>
+        </div>
+      <% } %>
+    </div>
+  </article>
+</section>
+
+<section class="reports-chart-row" aria-label="Acquisition charts">
+  <article class="card panel">
+    <header class="reports-card-header">
+      <p class="label-caps">Timeline</p>
+      <h3>Acquisitions by Month</h3>
+    </header>
+    <div class="reports-card-body reports-chart-card-body">
+      <% if (!charts.acquisitionByMonth.length) { %>
+        <p class="muted-text reports-chart-empty meta">No purchase date data available.</p>
+      <% } else { %>
+        <div class="reports-chart-wrap">
+          <canvas id="reports-acquisition-chart" aria-label="Firearms acquired by month" role="img"></canvas>
+        </div>
+      <% } %>
+    </div>
+  </article>
+
+  <article class="card panel">
+    <header class="reports-card-header">
+      <p class="label-caps">Pricing</p>
+      <h3>Average Purchase Price by Year</h3>
+    </header>
+    <div class="reports-card-body reports-chart-card-body">
+      <% if (!charts.avgPriceByYear.length) { %>
+        <p class="muted-text reports-chart-empty meta">No purchase price data available.</p>
+      <% } else { %>
+        <div class="reports-chart-wrap">
+          <canvas id="reports-avgprice-chart" aria-label="Average purchase price by year" role="img"></canvas>
+        </div>
+      <% } %>
+    </div>
+  </article>
+</section>
+
+<section class="reports-chart-row" aria-label="Condition and manufacturer charts">
+  <article class="card panel">
+    <header class="reports-card-header">
+      <p class="label-caps">Condition</p>
+      <h3>Condition Overview</h3>
+    </header>
+    <div class="reports-card-body reports-chart-card-body">
+      <% if (!charts.byCondition.length) { %>
+        <p class="muted-text reports-chart-empty meta">No condition data available.</p>
+      <% } else { %>
+        <div class="reports-chart-wrap">
+          <canvas id="reports-condition-chart" aria-label="Collection by condition" role="img"></canvas>
+        </div>
+      <% } %>
+    </div>
+  </article>
+
+  <article class="card panel">
+    <header class="reports-card-header">
+      <p class="label-caps">Manufacturer</p>
+      <h3>By Make</h3>
+    </header>
+    <div class="reports-card-body reports-chart-card-body">
+      <% if (!charts.byMake.length) { %>
+        <p class="muted-text reports-chart-empty meta">No manufacturer data available.</p>
+      <% } else { %>
+        <div class="reports-chart-wrap">
+          <canvas id="reports-make-chart" aria-label="Collection by manufacturer" role="img"></canvas>
+        </div>
+      <% } %>
+    </div>
+  </article>
+</section>
+
+<section class="reports-disposition" aria-label="Disposition tracking">
+  <h3 class="reports-section-title label-caps">Disposition Tracking</h3>
+  <div class="reports-stat-grid" role="list" aria-label="Disposition statistics">
+    <div class="reports-stat stat-card" role="listitem">
+      <span class="reports-stat-value stat-value mono"><%= disposition.disposedCount %></span>
+      <span class="reports-stat-label stat-label label-caps">Sold / Transferred</span>
+    </div>
+    <div class="reports-stat stat-card" role="listitem">
+      <span class="reports-stat-value stat-value mono">
+        $<%= disposition.totalProceeds.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 }) %>
+      </span>
+      <span class="reports-stat-label stat-label label-caps">Total Proceeds</span>
+    </div>
+    <div class="reports-stat stat-card" role="listitem">
+      <span class="reports-stat-value stat-value mono">
+        <%= disposition.avgHoldDays != null ? Math.round(disposition.avgHoldDays) + 'd' : '—' %>
+      </span>
+      <span class="reports-stat-label stat-label label-caps">Avg Hold Time</span>
+    </div>
+  </div>
+</section>
+
+<% } %>
+
+<script type="application/json" id="reports-charts-data"><%- JSON.stringify(charts || {}).replace(/</g, '\\u003c') %></script>

--- a/src/views/reports/index.ejs
+++ b/src/views/reports/index.ejs
@@ -1,0 +1,10 @@
+<%
+  const content = include('./index-content', locals);
+%>
+<%- include('../partials/layout', {
+  ...locals,
+  body: content,
+  pageTitle: 'Reports',
+  pageClass: 'page-reports',
+  pageScripts: ['/static/js/chart.min.js', '/static/js/reports-charts.js']
+}) %>

--- a/tests/integration/reports.integration.test.js
+++ b/tests/integration/reports.integration.test.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('supertest');
+
+const { createApp } = require('../../src/app/createApp');
+
+function testConfig(databasePath) {
+  return {
+    port: 0,
+    sessionSecret: 'test-secret',
+    adminUser: 'admin',
+    adminPass: 'password123',
+    databasePath
+  };
+}
+
+function extractCsrfToken(html) {
+  const match = html.match(/<input type="hidden" name="_csrf" value="([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+describe('reports routes', () => {
+  let app;
+  let dbPath;
+  let agent;
+
+  beforeEach(async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-reports-'));
+    dbPath = path.join(tempDir, 'app.db');
+    app = await createApp({ config: testConfig(dbPath) });
+    agent = request.agent(app);
+
+    const loginPage = await agent.get('/login');
+    const loginCsrfToken = extractCsrfToken(loginPage.text);
+
+    await agent
+      .post('/login')
+      .type('form')
+      .send({ username: 'admin', password: 'password123', _csrf: loginCsrfToken });
+
+    const changePasswordPage = await agent.get('/change-password');
+    const changeCsrfToken = extractCsrfToken(changePasswordPage.text);
+
+    await agent
+      .post('/change-password')
+      .type('form')
+      .send({
+        current_password: 'password123',
+        new_password: 'newSecurePassword123',
+        confirm_password: 'newSecurePassword123',
+        _csrf: changeCsrfToken
+      });
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  test('GET /reports renders with page title', async () => {
+    const res = await agent.get('/reports');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('Reports — Pew Pew Collection');
+  });
+
+  test('GET /reports shows empty state when no firearms exist', async () => {
+    const res = await agent.get('/reports');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('No data yet');
+    expect(res.text).toContain('Add your first firearm');
+  });
+
+  test('GET /reports redirects to login when unauthenticated', async () => {
+    const unauthAgent = request.agent(app);
+    const res = await unauthAgent.get('/reports');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/login');
+  });
+
+  test('GET /reports shows nav link to Reports', async () => {
+    const res = await agent.get('/reports');
+
+    expect(res.status).toBe(200);
+    expect(res.text).toContain('href="/reports"');
+  });
+});

--- a/tests/unit/reports.service.test.js
+++ b/tests/unit/reports.service.test.js
@@ -1,0 +1,128 @@
+const { createReportsService } = require('../../src/features/reports/reports.service');
+
+function makeRepository(overrides = {}) {
+  return {
+    getCollectionSummary: jest.fn(() => ({
+      total_firearms: 10,
+      total_value: 12000,
+      active_value: 8000,
+      sold_value: 4000,
+      active_count: 7,
+      sold_count: 2,
+      lost_count: 1,
+      repair_count: 0,
+      transit_count: 0
+    })),
+    getBreakdownByType: jest.fn(() => ([{ label: 'Pistol', count: 6 }, { label: 'Rifle', count: 4 }])),
+    getBreakdownByCaliber: jest.fn(() => ([{ label: '9mm', count: 5 }])),
+    getBreakdownByMake: jest.fn(() => ([{ label: 'Glock', count: 4 }])),
+    getAcquisitionByMonth: jest.fn(() => ([{ month: '2024-01', count: 3 }])),
+    getAvgPriceByYear: jest.fn(() => ([{ year: '2024', avg_price: 1200, count: 3 }])),
+    getDispositionStats: jest.fn(() => ({
+      disposed_count: 2,
+      total_proceeds: 4000,
+      avg_hold_days: 365.5
+    })),
+    getConditionBreakdown: jest.fn(() => ([{ label: 'Excellent', count: 5 }])),
+    ...overrides
+  };
+}
+
+describe('reports service', () => {
+  test('returns formatted report data', () => {
+    const repo = makeRepository();
+    const service = createReportsService(repo);
+    const result = service.getReports();
+
+    expect(result.summary.totalFirearms).toBe(10);
+    expect(result.summary.totalValue).toBe(12000);
+    expect(result.summary.activeCount).toBe(7);
+    expect(result.summary.activeValue).toBe(8000);
+    expect(result.summary.soldCount).toBe(2);
+    expect(result.summary.soldValue).toBe(4000);
+    expect(result.summary.lostCount).toBe(1);
+    expect(result.summary.repairCount).toBe(0);
+    expect(result.summary.transitCount).toBe(0);
+  });
+
+  test('returns chart data arrays', () => {
+    const repo = makeRepository();
+    const service = createReportsService(repo);
+    const result = service.getReports();
+
+    expect(result.charts.byType).toHaveLength(2);
+    expect(result.charts.byCaliber).toHaveLength(1);
+    expect(result.charts.byMake).toHaveLength(1);
+    expect(result.charts.acquisitionByMonth).toHaveLength(1);
+    expect(result.charts.avgPriceByYear).toHaveLength(1);
+    expect(result.charts.byCondition).toHaveLength(1);
+  });
+
+  test('returns formatted disposition data', () => {
+    const repo = makeRepository();
+    const service = createReportsService(repo);
+    const result = service.getReports();
+
+    expect(result.disposition.disposedCount).toBe(2);
+    expect(result.disposition.totalProceeds).toBe(4000);
+    expect(result.disposition.avgHoldDays).toBe(365.5);
+  });
+
+  test('isEmpty is false when collection has firearms', () => {
+    const repo = makeRepository();
+    const service = createReportsService(repo);
+    const result = service.getReports();
+
+    expect(result.isEmpty).toBe(false);
+  });
+
+  test('isEmpty is true when collection is empty', () => {
+    const repo = makeRepository({
+      getCollectionSummary: jest.fn(() => ({
+        total_firearms: 0,
+        total_value: 0,
+        active_value: 0,
+        sold_value: 0,
+        active_count: 0,
+        sold_count: 0,
+        lost_count: 0,
+        repair_count: 0,
+        transit_count: 0
+      }))
+    });
+    const service = createReportsService(repo);
+    const result = service.getReports();
+
+    expect(result.isEmpty).toBe(true);
+  });
+
+  test('handles null summary values gracefully', () => {
+    const repo = makeRepository({
+      getCollectionSummary: jest.fn(() => ({
+        total_firearms: null,
+        total_value: null,
+        active_value: null,
+        sold_value: null,
+        active_count: null,
+        sold_count: null,
+        lost_count: null,
+        repair_count: null,
+        transit_count: null
+      })),
+      getDispositionStats: jest.fn(() => ({
+        disposed_count: null,
+        total_proceeds: null,
+        avg_hold_days: null
+      }))
+    });
+    const service = createReportsService(repo);
+    const result = service.getReports();
+
+    expect(result.summary.totalFirearms).toBe(0);
+    expect(result.summary.totalValue).toBe(0);
+    expect(result.disposition.disposedCount).toBe(0);
+    expect(result.disposition.totalProceeds).toBe(0);
+    expect(result.disposition.avgHoldDays).toBeNull();
+    expect(result.isEmpty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `/reports` page with a full analytics dashboard computed entirely via SQL aggregates (no in-memory JS aggregation)
- New `src/features/reports/` feature directory following the established controller/service/routes pattern
- New `src/infra/db/repositories/reports.repository.js` with all SQL queries
- Charts rendered with the existing Chart.js instance, themed to match dark/light modes
- Page title is "Reports — Pew Pew Collection"; nav link added between Inventory and Profile

## What's included

**Collection Summary**
- Total firearms, total value, active value
- Per-status counts (Active, Sold, Lost, In Repair, In Transit) and values

**Breakdown charts**
- By firearm type (doughnut)
- By caliber (bar, top 15)
- By manufacturer/make (bar, top 15)

**Acquisition timeline**
- Firearms added per month (bar)
- Average purchase price by year (bar)

**Condition overview**
- Condition distribution (doughnut)

**Disposition tracking**
- Sold/transferred count, total proceeds, average hold time (purchase → disposition date)

**Empty state**
- Renders without error on an empty collection with a prompt to add the first firearm

## Test plan

- [ ] `GET /reports` returns 200 for authenticated users
- [ ] `GET /reports` redirects to `/login` for unauthenticated users
- [ ] Empty-state message shown when no firearms exist
- [ ] Page title contains "Reports — Pew Pew Collection"
- [ ] Reports nav link is present and active on `/reports`
- [ ] All 151 unit + integration tests pass (`npx jest --runInBand`)
- [ ] ESLint clean (`npm run lint`)

Closes #458

---
_Generated by [Claude Code](https://claude.ai/code/session_0193XzzcDANpP5GqVUHw9SaF)_