### PR TITLE
feat(firearms): add printable insurance report (#147)

### DIFF
--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -36,6 +36,15 @@ function createFirearmsController(firearmsService) {
       res.end();
     },
 
+    insuranceReport(req, res) {
+      const items = firearmsService.list();
+      const totalValue = items.reduce((sum, i) => sum + (i.purchase_price || 0), 0);
+      const reportDate = new Date().toLocaleDateString('en-US', {
+        year: 'numeric', month: 'long', day: 'numeric'
+      });
+      res.render('firearms/insurance-report', { items, totalValue, reportDate });
+    },
+
     showNew(req, res) {
       res.render('firearms/new', { item: {}, fieldErrors: {}, error: null });
     },

--- a/src/features/firearms/firearms.routes.js
+++ b/src/features/firearms/firearms.routes.js
@@ -9,6 +9,7 @@ function createFirearmsRoutes(firearmsController) {
   router.get('/import/template', requireAuth, firearmsController.downloadTemplate);
   router.get('/import', requireAuth, firearmsController.showImport);
   router.post('/import', requireAuth, express.text({ limit: '2mb', type: 'text/plain' }), firearmsController.importCsv);
+  router.get('/report', requireAuth, firearmsController.insuranceReport);
   router.get('/new', requireAuth, firearmsController.showNew);
   router.post('/', requireAuth, firearmsController.create);
   router.get('/:id', requireAuth, firearmsController.show);

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1976,3 +1976,57 @@ main:focus-visible {
     height: 220px;
   }
 }
+
+@media print {
+  @page { size: landscape; margin: 15mm; }
+
+  .no-print { display: none !important; }
+  .print-only { display: block !important; }
+
+  body { background: #fff; color: #000; }
+
+  .topbar,
+  .app-footer { display: none !important; }
+
+  .print-report .table-wrapper {
+    box-shadow: none;
+    border: 1px solid #ccc;
+  }
+
+  .print-report .table th,
+  .print-report .table td {
+    font-size: 10px;
+    padding: 5px 8px;
+    color: #000;
+    border-color: #ccc;
+  }
+
+  .print-report .badge {
+    border: 1px solid currentColor;
+    background: transparent;
+    color: #000;
+  }
+
+  .print-report .muted-text { color: #666; }
+
+  .report-total-row td { border-top: 2px solid #000; }
+
+  tr { page-break-inside: avoid; }
+
+  .report-header {
+    margin-bottom: 12mm;
+  }
+
+  .report-title {
+    font-size: 18px;
+    margin: 0 0 4px;
+  }
+
+  .report-meta {
+    font-size: 11px;
+    color: #444;
+    margin: 0;
+  }
+}
+
+.print-only { display: none; }

--- a/src/views/firearms/index-content.ejs
+++ b/src/views/firearms/index-content.ejs
@@ -13,6 +13,7 @@
     <div class="action-bar-actions">
       <a class="btn btn-secondary" href="/firearms/import">Import CSV</a>
       <a class="btn btn-secondary" href="/firearms/export" download="firearms.csv">Export CSV</a>
+      <a class="btn btn-secondary" href="/firearms/report">Insurance Report</a>
       <a class="btn btn-primary" href="/firearms/new">+ Add Firearm</a>
     </div>
   </div>

--- a/src/views/firearms/insurance-report-content.ejs
+++ b/src/views/firearms/insurance-report-content.ejs
@@ -1,0 +1,115 @@
+  <section class="app-hero no-print">
+    <p class="label-caps">Inventory</p>
+    <h2 class="page-title">Insurance Report</h2>
+    <p class="page-subtitle meta">Full inventory snapshot for insurance documentation.</p>
+  </section>
+
+  <div class="action-bar page-section panel no-print">
+    <div class="title-group">
+      <p class="label-caps">Report</p>
+      <h3 class="card-title">Insurance Report</h3>
+      <small class="meta"><%= items.length %> item<%= items.length === 1 ? '' : 's' %> on record</small>
+    </div>
+    <div class="action-bar-actions">
+      <a class="btn btn-secondary" href="/firearms">&#8592; Back to Inventory</a>
+      <button class="btn btn-primary" onclick="window.print()">Print Report</button>
+    </div>
+  </div>
+
+  <div class="report-header print-only">
+    <h2 class="report-title">Insurance Report &mdash; Pew Pew Collection</h2>
+    <p class="report-meta">Generated: <%= reportDate %> &nbsp;&bull;&nbsp; <%= items.length %> item<%= items.length === 1 ? '' : 's' %></p>
+  </div>
+
+  <% if (!items.length) { %>
+    <section class="card empty-state panel no-print">
+      <h3>No firearms on record</h3>
+      <p class="meta">Add firearms to your inventory before generating a report.</p>
+      <div class="empty-state-actions">
+        <a class="btn btn-primary" href="/firearms/new">Add Firearm</a>
+      </div>
+    </section>
+  <% } else { %>
+    <div class="table-wrapper panel">
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">#</th>
+            <th scope="col">Make</th>
+            <th scope="col">Model</th>
+            <th scope="col">Type</th>
+            <th scope="col">Caliber</th>
+            <th scope="col">Serial Number</th>
+            <th scope="col">Condition</th>
+            <th scope="col">Status</th>
+            <th scope="col">Purchase Date</th>
+            <th scope="col">Purchase Value</th>
+          </tr>
+        </thead>
+        <tbody>
+        <% items.forEach((item, index) => { %>
+          <tr>
+            <td class="mono" data-label="#"><%- index + 1 %></td>
+            <td data-label="Make"><%= item.make %></td>
+            <td data-label="Model"><%= item.model %></td>
+            <td data-label="Type">
+              <% if (item.firearm_type) { %>
+                <%= item.firearm_type %>
+              <% } else { %>
+                <span class="muted-text meta">-</span>
+              <% } %>
+            </td>
+            <td class="mono" data-label="Caliber">
+              <% if (item.caliber) { %>
+                <%= item.caliber %>
+              <% } else { %>
+                <span class="muted-text meta">-</span>
+              <% } %>
+            </td>
+            <td class="mono" data-label="Serial Number">
+              <% if (item.serial) { %>
+                <%= item.serial %>
+              <% } else { %>
+                <span class="muted-text meta">-</span>
+              <% } %>
+            </td>
+            <td data-label="Condition">
+              <% if (item.condition) { %>
+                <%= item.condition %>
+              <% } else { %>
+                <span class="muted-text meta">-</span>
+              <% } %>
+            </td>
+            <td data-label="Status">
+              <% if (item.status) { %>
+                <%= item.status %>
+              <% } else { %>
+                <span class="muted-text meta">-</span>
+              <% } %>
+            </td>
+            <td class="mono" data-label="Purchase Date">
+              <% if (item.purchase_date) { %>
+                <%= item.purchase_date %>
+              <% } else { %>
+                <span class="muted-text meta">-</span>
+              <% } %>
+            </td>
+            <td class="mono" data-label="Purchase Value">
+              <% if (item.purchase_price != null && item.purchase_price !== '') { %>
+                $<%= Number(item.purchase_price).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) %>
+              <% } else { %>
+                <span class="muted-text meta">-</span>
+              <% } %>
+            </td>
+          </tr>
+        <% }) %>
+        </tbody>
+        <tfoot>
+          <tr class="report-total-row">
+            <td colspan="9" class="text-right"><strong>Total Purchase Value</strong></td>
+            <td class="mono"><strong>$<%= Number(totalValue).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) %></strong></td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  <% } %>

--- a/src/views/firearms/insurance-report.ejs
+++ b/src/views/firearms/insurance-report.ejs
@@ -1,0 +1,4 @@
+<%
+  const content = include('./insurance-report-content', locals);
+%>
+<%- include('../partials/layout', { ...locals, body: content, pageTitle: 'Insurance Report', pageClass: 'print-report' }) %>

--- a/tests/integration/firearms.integration.test.js
+++ b/tests/integration/firearms.integration.test.js
@@ -588,4 +588,53 @@ describe('firearms routes', () => {
       expect(response.status).toBe(200);
     });
   });
+
+  describe('GET /firearms/report', () => {
+    test('returns 200 with Insurance Report heading', async () => {
+      const response = await agent.get('/firearms/report');
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('Insurance Report');
+    });
+
+    test('shows generated date and item count', async () => {
+      const response = await agent.get('/firearms/report');
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('Generated:');
+      expect(response.text).toContain('0 items');
+    });
+
+    test('shows firearm data and total value', async () => {
+      const newPage = await agent.get('/firearms/new');
+      const csrfToken = extractCsrfToken(newPage.text);
+      await agent
+        .post('/firearms')
+        .type('form')
+        .send({
+          make: 'Ruger',
+          model: '10/22',
+          serial: 'SN99',
+          caliber: '.22 LR',
+          purchase_date: '2024-06-01',
+          purchase_price: '350',
+          condition: 'Excellent',
+          status: 'Active',
+          firearm_type: 'Rifle',
+          _csrf: csrfToken
+        });
+
+      const response = await agent.get('/firearms/report');
+      expect(response.status).toBe(200);
+      expect(response.text).toContain('Ruger');
+      expect(response.text).toContain('10/22');
+      expect(response.text).toContain('SN99');
+      expect(response.text).toContain('350.00');
+    });
+
+    test('redirects unauthenticated users to login', async () => {
+      const unauthed = request(app);
+      const response = await unauthed.get('/firearms/report');
+      expect(response.status).toBe(302);
+      expect(response.headers.location).toMatch(/\/login/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `GET /firearms/report` — an authenticated route that renders the full inventory as a printable insurance report
- Report includes: make, model, type, caliber, serial number, condition, status, purchase date, purchase value, and a total value footer
- One-click "Print Report" button triggers `window.print()`; `@media print` CSS forces landscape orientation (`@page { size: landscape }`) and hides nav/footer/buttons
- "Insurance Report" button added to the Inventory action bar for one-click access
- Zero new runtime dependencies — uses the browser's built-in print dialog, fully offline

Closes #147

## Test plan

- [ ] `npm test` passes (28 integration tests, 4 new for this route)
- [ ] `npm run lint` passes clean
- [ ] Navigate to `/firearms` → click "Insurance Report" → page loads with full inventory table
- [ ] Click "Print Report" → browser print dialog opens in landscape orientation with nav/footer hidden
- [ ] Verify total purchase value footer sums correctly
- [ ] Verify unauthenticated `GET /firearms/report` redirects to `/login`

https://claude.ai/code/session_01GDvE2XczYPME8dqGox1q58

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDvE2XczYPME8dqGox1q58)_