### PR TITLE
docs: trim README and seed wiki source pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Pew Pew Collection
 
-Pew Pew Collection (PPCollection) is a self-hosted, offline-first firearm inventory app for tracking and managing a personal collection locally with no cloud dependency, built with Node.js/Express and SQLite.
+Self-hosted, offline-first firearm inventory app — track and manage a personal
+collection locally with no cloud dependency. Node.js / Express + SQLite, no
+build step, one Docker command to run.
 
 [![Release](https://github.com/Gogorichielab/PPCollection/actions/workflows/Release.yml/badge.svg)](https://github.com/Gogorichielab/PPCollection/actions/workflows/Release.yml)
 [![CI](https://github.com/Gogorichielab/PPCollection/actions/workflows/Ci.yml/badge.svg)](https://github.com/Gogorichielab/PPCollection/actions/workflows/Ci.yml)
@@ -9,28 +11,27 @@ Pew Pew Collection (PPCollection) is a self-hosted, offline-first firearm invent
 
 ![Dashboard](docs/screenshots/dashboard.png)
 
-## Features
+## What it does
 
-- **Full inventory CRUD** — Add, edit, duplicate, and delete firearm records with make, model, serial, caliber, type, condition, status, location, purchase details, warranty, and notes
-- **Disposition tracking** — Records sold/lost/stolen firearms with transferee name, address, date, and reason; disposition fields are included in CSV exports
-- **Dashboard** — Collection overview with recent activity feed, type breakdown chart, and purchase-value-by-year chart
-- **Stats** — Dedicated analytics page (nav: "Stats") with collection summary, breakdown charts by type/caliber/make/condition, acquisition trends by month, average price by year, and disposition statistics
-- **Insurance report** — Print-friendly inventory report with total purchase value for policy documentation
-- **Search & filter** — Real-time search across all fields; filter by status, condition, and firearm type; sort by any column; the "All items" count badge updates live as filters are applied; inventory rows collapse into cards on mobile viewports
-- **Fast inventory navigation** — Click any inventory row (or use keyboard focus/Enter) to open firearm details
-- **CSV export & import** — Download your entire inventory with one click, or bulk-import records from a CSV file (template provided)
-- **Serial number uniqueness** — Database-enforced unique constraint on serial numbers prevents duplicate entries; validated during both form submission and CSV import
-- **Bcrypt authentication** — Session-based login with bcrypt-hashed passwords and a forced password change on first login
-- **Profile management** — Update username, change password, and toggle display preferences from the profile page
-- **Dark & light mode** — Theme preference persists per user across sessions; the toggle button exposes an accessible `aria-label` announcing the destination state for screen readers
-- **Keyboard & screen-reader accessible** — Skip-to-main navigation for keyboard users, and descriptive labels on interactive controls so screen readers announce the correct action
-- **CSRF protection** — All forms protected via the double-submit cookie pattern
-- **Fully offline** — Zero internet requirement at runtime; no telemetry, no external services
-- **Optional update notifications** — Opt-in check against GitHub Releases (14-day cached); disabled by default
-- **Single SQLite file** — All data in one portable file; backup with a single `cp` command
-- **Docker ready** — Up and running in under 60 seconds from GHCR
+- **Inventory CRUD** — add, edit, duplicate, and delete firearm records with
+  make, model, serial, caliber, type, condition, status, location, purchase
+  details, warranty, and notes
+- **Disposition tracking** — records sold/lost/stolen items with transferee,
+  date, and reason; included in CSV exports
+- **Dashboard and stats** — recent activity, type/caliber/make breakdowns,
+  acquisition trends, average price by year
+- **Insurance report** — print-friendly inventory with total purchase value
+- **Search, filter, sort** — real-time across all fields; mobile rows collapse
+  to cards
+- **CSV import & export** — round-trippable, with a template
+- **Single-admin auth** — bcrypt-hashed password, forced change on first
+  login, CSRF on every form
+- **Fully offline** — zero internet at runtime; the GitHub Releases update
+  check is opt-in
+- **One SQLite file** — back up your whole collection with `cp`
+- **Docker ready** — multi-arch image on GHCR
 
-## Quick Start (Docker)
+## Quick start
 
 ```bash
 docker run -d \
@@ -44,124 +45,35 @@ docker run -d \
   ghcr.io/gogorichielab/ppcollection:latest
 ```
 
-Open `http://localhost:3000`. On first login you will be prompted to change the default password.
+Open <http://localhost:3000> and log in. You will be prompted to change the
+password on first login. Your data lives in `./data/app.db` on the host —
+back up that directory to back up your collection.
 
-> **Your data lives in `./data/app.db` on the host.** The `-v "$(pwd)/data:/data"`
-> bind mount is what persists your inventory across container updates. Back up the
-> `data/` directory to back up your collection. `docker run` requires an absolute
-> host path here — a bare `./data` is interpreted as an anonymous volume, which
-> Docker discards every time the container is recreated. If you prefer a managed
-> volume instead of a host directory, use `-v ppcollection_data:/data`.
-
-## Configuration
-
-| Variable | Purpose | Default | Notes |
-|---|---|---|---|
-| `SESSION_SECRET` | Session signing secret | `ppcollection_dev_secret` | **Required in production.** Generate with `openssl rand -hex 32` |
-| `ADMIN_USERNAME` | Username for the admin account | `admin` | Used for initial login |
-| `ADMIN_PASSWORD` | Initial admin password | `changeme` | **Required in production for first-run.** A change is forced on first login. The app refuses to seed a fresh deployment with the documented default. |
-| `PORT` | HTTP port the server listens on | `3000` | Runtime server port |
-| `DATABASE_PATH` | Path to the SQLite database file | `/data/app.db` | Defaults to `/data` in Docker |
-| `DATA_DIR` | Allowed base directory for database files | `/data` in Docker, `<cwd>/data` otherwise | `DATABASE_PATH` must stay inside this directory |
-| `TRUST_PROXY` | Trust `X-Forwarded-Proto` from a reverse proxy | `false` | Set to `true` when running behind nginx, Caddy, or Traefik |
-| `SECURE_COOKIES` | Set the `Secure` flag on session and CSRF cookies | `true` in production, `false` otherwise | When unset, defaults to `true` whenever `NODE_ENV=production` (the published Docker image always sets this). Set `SECURE_COOKIES=false` to opt out — required if you run the app on plain HTTP in production. Requires `TRUST_PROXY=true` when behind an HTTPS reverse proxy. |
-| `UPDATE_CHECK` | Check GitHub Releases for new versions | `false` | Set to `true` to enable in-app update notifications; results are cached for 14 days |
-| `AUDIT_VERBOSE` | Include username/serial in audit log events | `false` | Keep disabled to minimize sensitive metadata in logs |
-
-## Security Notes
-
-> **Reverse proxy users:** If you are running PPCollection behind
-> nginx, Caddy, or Traefik with HTTPS, set `TRUST_PROXY=true`. Secure
-> cookies are now on by default when `NODE_ENV=production` (which is
-> always the case in the published Docker image), so you no longer
-> need to set `SECURE_COOKIES=true` explicitly — but `TRUST_PROXY` is
-> still required so Express recognizes the proxied request as HTTPS,
-> otherwise sessions will silently fail to persist.
-
-> **Plain-HTTP production deployments:** If you intentionally run the
-> app on plain HTTP in production (no TLS terminator at all), the
-> browser will refuse to set or send `Secure` cookies and sessions
-> will break. Set `SECURE_COOKIES=false` to opt out and restore plain
-> session cookies. This is also the upgrade path from earlier versions
-> if you were running on plain HTTP without realizing it.
-
-## Upgrading
-
-Existing deployments continue to work without configuration changes.
-The guards introduced in v2.x only affect **new installations** that
-have never seeded an admin account. If you've been running the app,
-your account hash is already stored in `app.db` and no action is
-required.
-
-**Secure cookies (v2.0.0+):** Session and CSRF cookies now have the
-`Secure` flag enabled by default when `NODE_ENV=production` (the
-published Docker image always sets this). Before v2.0.0 the flag was
-opt-in.
-
-| If you run the app... | What you need to do |
-|---|---|
-| Behind an HTTPS reverse proxy with `TRUST_PROXY=true` | Nothing. |
-| Behind an HTTPS reverse proxy without `TRUST_PROXY` | Set `TRUST_PROXY=true` so Express honors the `X-Forwarded-Proto` header. |
-| On plain HTTP in production (no TLS) | Add `SECURE_COOKIES=false` to restore plain cookies; otherwise sessions will silently fail. |
-| Locally (any non-production `NODE_ENV`) | No change. Default is still off. |
-
-**`SESSION_SECRET` is required in production (v2.0.1+):** The app
-refuses to start if `SESSION_SECRET` is unset or matches the
-hard-coded default. Generate one with `openssl rand -hex 32`.
-
-**`ADMIN_PASSWORD` is required for first-run in production (v2.0.0+):**
-The app refuses to start on a fresh install if `ADMIN_PASSWORD` is
-unset or `changeme`. Set a strong value before the first start:
-
-```bash
-ADMIN_PASSWORD="$(openssl rand -base64 24)"
-```
-
-## Operations
-
-- **Liveness probe:** `GET /health` returns `200 { status, version, uptime }` without
-  requiring authentication and is excluded from the request log. Use it from a
-  reverse proxy, Docker `HEALTHCHECK`, or external monitor.
-- **Container health:** The published image declares `HEALTHCHECK` against
-  `/health`. `docker inspect --format '{{.State.Health.Status}}' ppcollection`
-  reports `healthy` when the HTTP server is serving requests.
-- **Graceful shutdown:** The process traps `SIGTERM`/`SIGINT`, stops accepting
-  new connections, drains in-flight requests, and closes the SQLite database
-  before exiting. `docker compose` is configured with a 15s
-  `stop_grace_period`.
-- **Audit logs:** Login, logout, password, and firearm create/update/delete/import
-  events are emitted as structured JSON logs on stdout for host-side log
-  collection. By default, usernames/serials are redacted unless
-  `AUDIT_VERBOSE=true`.
-
-## Screenshots
-
-| Inventory | Firearm Detail |
-|---|---|
-| ![Inventory](docs/screenshots/inventory.png) | ![Firearm Detail](docs/screenshots/firearm-detail.png) |
-
-| Add Firearm | Stats |
-|---|---|
-| ![Add Firearm](docs/screenshots/add-firearm.png) | ![Stats](docs/screenshots/stats.png) |
-
-| Insurance Report | Profile |
-|---|---|
-| ![Insurance Report](docs/screenshots/insurance-report.png) | ![Profile](docs/screenshots/profile.png) |
+> Use an absolute host path for the volume (or a named volume like
+> `-v ppcollection_data:/data`). Docker treats a bare `./data` as an
+> anonymous volume and discards it whenever the container is recreated.
 
 ## Documentation
 
-Full documentation: [https://gogorichielab.github.io/PPCollection/](https://gogorichielab.github.io/PPCollection/)
+Full docs live in the [wiki](https://github.com/Gogorichielab/PPCollection/wiki):
+
+- **[Installation](https://github.com/Gogorichielab/PPCollection/wiki/Installation)** — Docker, Docker Compose, and from-source setups
+- **[Configuration](https://github.com/Gogorichielab/PPCollection/wiki/Configuration)** — every environment variable, with production defaults
+- **[Security](https://github.com/Gogorichielab/PPCollection/wiki/Security)** — reverse-proxy setup, `TRUST_PROXY`, secure cookies, CSRF, audit logs
+- **[Operations](https://github.com/Gogorichielab/PPCollection/wiki/Operations)** — health probe, graceful shutdown, backup and restore
+- **[Upgrading](https://github.com/Gogorichielab/PPCollection/wiki/Upgrading)** — version-specific notes (v2.0.0 secure-cookies default, v2.0.1 session-secret guard)
+- **[Architecture](https://github.com/Gogorichielab/PPCollection/wiki/Architecture)** — code layout and request lifecycle
+- **[Screenshots](https://github.com/Gogorichielab/PPCollection/wiki/Screenshots)** — full gallery
+- **[FAQ](https://github.com/Gogorichielab/PPCollection/wiki/FAQ)** — common questions and recovery procedures
 
 ## Contributing
 
-Contributing guide: [CONTRIBUTING.md](CONTRIBUTING.md)
-
-PPCollection uses `.github/CODEOWNERS` to request maintainer review
-automatically, especially for high-blast-radius areas such as GitHub Actions
-configuration, Docker runtime files, release configuration, and database
-migrations. Maintainers should enable branch protection on `main` that
-requires Code Owner review before merge.
+See [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[Contributing page](https://github.com/Gogorichielab/PPCollection/wiki/Contributing)
+in the wiki. The project uses `.github/CODEOWNERS` to request maintainer
+review automatically, especially for GitHub Actions, Docker runtime files,
+release configuration, and database migrations.
 
 ## License
 
-Licensed under GNU GPL v3 or later: [LICENSE](LICENSE)
+Licensed under GNU GPL v3 or later — see [LICENSE](LICENSE).

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -1,0 +1,104 @@
+# Architecture
+
+Pew Pew Collection is a single-process Node.js / Express app rendering EJS
+server-side, backed by SQLite. There is no build step, no bundler, no
+frontend framework.
+
+## Layered structure
+
+```
+src/
+├── server.js                 # Entry point — calls createApp() and listens
+├── app/
+│   ├── createApp.js          # App factory — wires middleware + routes + DI
+│   ├── middleware/auth.js    # requireAuth + must-change-password redirect
+│   └── routes/index.js       # Mounts feature routers
+├── features/
+│   ├── auth/                 # Login, change-password, profile, theme toggle
+│   ├── firearms/             # Inventory CRUD, CSV import/export
+│   └── home/                 # Dashboard
+│       └── (each contains <feature>.controller.js,
+│                            <feature>.routes.js,
+│                            <feature>.service.js,
+│                            <feature>.validators.js [if needed])
+├── infra/
+│   ├── config/index.js       # Reads + validates env vars; exports getConfig()
+│   └── db/
+│       ├── client.js         # better-sqlite3 connection
+│       ├── migrate.js        # Numbered SQL migration runner
+│       ├── migrations/       # 001_initial_schema.sql, 002_settings_table.sql, ...
+│       └── repositories/     # firearms.repository.js, settings.repository.js
+├── services/
+│   └── version.service.js    # Opt-in GitHub Releases lookup (UPDATE_CHECK)
+├── shared/utils/csv.js       # CSV parse + serialise
+├── public/
+│   ├── css/styles.css        # Single stylesheet, dark + light via [data-theme]
+│   └── js/                   # search.js, theme.js, firearm-form.js, etc.
+└── views/                    # EJS templates
+    ├── partials/layout.ejs
+    ├── auth/   firearms/   home/   errors/
+    └── (each feature has a *.ejs page + *-content.ejs partial)
+```
+
+## Layer rules
+
+- **Controllers** handle HTTP only and delegate to services.
+- **Services** contain business logic and delegate to repositories.
+- **Repositories** do SQL only — no business logic.
+- **Views** render EJS only; no inline styles (everything in `styles.css`),
+  and all mobile overrides go inside the existing `@media (max-width: 640px)`
+  block.
+
+## Request lifecycle
+
+1. `server.js` calls `createApp()` and binds the HTTP server.
+2. `createApp()` wires middleware: `helmet`, `cookie-parser`,
+   `express-session`, `csrf-csrf`, `morgan`, `method-override`, and
+   feature routers.
+3. A request to e.g. `GET /firearms/:id` hits the route in
+   `features/firearms/firearms.routes.js`, which calls the controller.
+4. The controller validates inputs via `firearms.validators.js`, calls
+   `firearms.service.js`, and renders an EJS view.
+5. The service calls `firearms.repository.js`, which runs a parameterized
+   SQL statement against the SQLite database.
+6. The response renders `views/firearms/<view>.ejs` inside
+   `partials/layout.ejs`.
+
+## Database
+
+- SQLite via `better-sqlite3` — synchronous, fast, single-file.
+- Schema changes are new numbered SQL migration files in
+  `src/infra/db/migrations/` (e.g. `004_*.sql`).
+- The migration runner records applied files in a `schema_migrations` table;
+  shipped migrations are immutable.
+- `settings` is a key/value table holding `username`, `password_hash`,
+  `must_change_password`, `theme`, `update_check_enabled`.
+- `maintenance_logs` and `range_sessions` tables exist in the initial schema
+  but have no UI yet — intentional, reserved for future features.
+
+## Technology stack
+
+| Layer | Technology |
+|---|---|
+| Runtime | Node.js >=20.0.0 <25.0.0 |
+| HTTP | Express.js v5 |
+| Templating | EJS, server-side rendered |
+| Database | SQLite via `better-sqlite3` |
+| Auth | Session-based, single admin, bcrypt cost 12 |
+| Sessions | `express-session` + `cookie-parser` |
+| CSRF | `csrf-csrf` double-submit cookie |
+| Rate limiting | `express-rate-limit` |
+| HTTP hardening | `helmet` with CSP enabled |
+| Logging | `morgan` for requests, structured JSON for audit |
+| Frontend assets | Plain CSS + vanilla JS in `src/public/`, no build step |
+| Testing | Jest + Supertest, `--runInBand` |
+| Linting | ESLint flat config |
+
+## CI
+
+- `ci.yml` — runs on every PR: lint, `npm run test:ci`, `npm audit`, Trivy
+  filesystem scan, Hadolint Dockerfile scan, coverage upload.
+- `release.yml` — runs on merge to `main`: semantic-release builds and pushes
+  the multi-arch Docker image to GHCR and tags the GitHub release.
+- `maintenance.yml` — daily at 04:00 UTC: stale-bot for issues / PRs, deletes
+  merged `codex/*` and `copilot/*` branches after 2 days.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -1,0 +1,57 @@
+# Configuration
+
+All configuration is via environment variables, read once at startup by
+`src/infra/config/index.js`. The published Docker image always sets
+`NODE_ENV=production`, which tightens several defaults.
+
+## Reference table
+
+| Variable | Purpose | Default | Notes |
+|---|---|---|---|
+| `PORT` | HTTP port the server listens on | `3000` | |
+| `SESSION_SECRET` | Session + CSRF cookie signing key | `ppcollection_dev_secret` | **Required in production.** Generate with `openssl rand -hex 32`. Production refuses to start if unset or equal to the default. |
+| `ADMIN_USERNAME` | Initial admin username | `admin` | Used to seed the local admin on first boot. Can be changed later from **Profile**. |
+| `ADMIN_PASSWORD` | Initial admin password | `changeme` | **Required for first-run in production.** Hashed with bcrypt (cost 12) on first boot, then only the hash is kept. A change is forced on first login. |
+| `DATABASE_PATH` | SQLite file location | `/data/app.db` in Docker, `<cwd>/data/app.db` otherwise | Must stay inside `DATA_DIR`. |
+| `DATA_DIR` | Allowed base directory for database files | `/data` in Docker, `<cwd>/data` otherwise | Path-traversal guard for `DATABASE_PATH`. |
+| `NODE_ENV` | Runtime mode | unset | `production` enables the first-run admin guard, the `SESSION_SECRET` guard, and secure-cookie defaults. |
+| `TRUST_PROXY` | Honor `X-Forwarded-Proto` from a reverse proxy | `false` | Set to `true` behind nginx, Caddy, or Traefik. Without it, secure cookies will silently fail behind a TLS terminator. |
+| `SECURE_COOKIES` | Force the `Secure` flag on session and CSRF cookies | `true` when `NODE_ENV=production`, else `false` | Set to `false` only for plain-HTTP production deployments. |
+| `UPDATE_CHECK` | Opt-in GitHub Releases lookup | `false` | Cached for 14 days. The only outbound network call the app makes. |
+| `AUDIT_VERBOSE` | Include username and serial in audit log lines | `false` | Keep disabled to minimize sensitive metadata on disk. |
+
+## Production checklist
+
+```bash
+NODE_ENV=production
+SESSION_SECRET=$(openssl rand -hex 32)
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=$(openssl rand -base64 24)
+TRUST_PROXY=true            # if behind nginx/Caddy/Traefik over HTTPS
+SECURE_COOKIES=true         # the production default; explicit doesn't hurt
+UPDATE_CHECK=false          # leave off unless you want the GitHub call
+```
+
+The first three are mandatory. The rest depend on your deployment shape — see
+[Security](Security).
+
+## Development defaults
+
+When `NODE_ENV` is unset (or anything other than `production`):
+
+- `SESSION_SECRET` falls back to `ppcollection_dev_secret`. Fine for local dev,
+  fatal in production.
+- `SECURE_COOKIES` defaults to `false`, so cookies work over plain HTTP at
+  `localhost:3000`.
+- The first-run admin guard is relaxed. `admin` / `changeme` will seed the
+  database. Change them in real deployments.
+
+## How the app reads config
+
+- `src/infra/config/index.js` parses `process.env` once at startup and exposes
+  a `getConfig()` function. Nothing else reads `process.env` directly.
+- The config layer warns when a misconfig is detected (e.g. `SECURE_COOKIES=true`
+  without `TRUST_PROXY=true` behind a proxy).
+- Sensitive values (`SESSION_SECRET`, `ADMIN_PASSWORD`) are never logged.
+
+See also: [Security](Security), [Operations](Operations), [Upgrading](Upgrading).

--- a/wiki/Contributing.md
+++ b/wiki/Contributing.md
@@ -1,0 +1,119 @@
+# Contributing
+
+Thanks for considering a contribution. The canonical contributor guide lives
+in the repo at
+[CONTRIBUTING.md](https://github.com/Gogorichielab/PPCollection/blob/main/CONTRIBUTING.md);
+this page is a higher-level overview.
+
+## Before you start
+
+- **File an issue first** for anything non-trivial. A short discussion up
+  front avoids reworking a PR that has the wrong shape.
+- **Stay inside the project values.** Privacy, offline-first, self-hosted
+  simplicity. See [Home](Home) and the project's `CLAUDE.md` / `AGENTS.md`
+  for the long form.
+- **Don't add a build step.** No bundlers, no transpilers, no frontend
+  frameworks. Plain CSS, vanilla JS, server-rendered EJS.
+
+## Local development
+
+Requires Node.js `>=20.0.0 <25.0.0` (the repo pins Node 20 via `.nvmrc`).
+
+```bash
+git clone https://github.com/Gogorichielab/PPCollection.git
+cd PPCollection
+nvm use
+npm ci
+npm run dev
+```
+
+The dev server runs at <http://localhost:3000>. SQLite is created at
+`./data/app.db`; migrations run automatically on boot.
+
+## Tests
+
+| Command | What it does |
+|---|---|
+| `npm test` | Unit + integration, no coverage |
+| `npm run test:unit` | Unit only |
+| `npm run test:integration` | Integration only |
+| `npm run test:ci` | Coverage + thresholds (what CI runs) |
+| `npm run test:watch` | TDD loop |
+| `npm run lint` | ESLint over `src` and `tests` |
+
+`--runInBand` is mandatory — SQLite + Jest deadlock if you parallelize.
+The npm scripts already pass it.
+
+Coverage thresholds (enforced in `test:ci`):
+
+- statements / lines / functions ≥ 90%
+- branches ≥ 75%
+
+## Where to put a test
+
+- `tests/unit/` — pure logic, single repository, or a single service in
+  isolation.
+- `tests/integration/` — anything that needs the full Express app via
+  Supertest.
+
+## Architecture rules
+
+- Controllers → services → repositories → SQL. Don't shortcut the layers.
+- No inline styles in EJS. Use `src/public/css/styles.css`.
+- Mobile overrides go inside the existing `@media (max-width: 640px)` block.
+  Don't add new media query blocks.
+- New schema goes in a new numbered migration file under
+  `src/infra/db/migrations/`. Never edit a migration that has shipped.
+
+See [Architecture](Architecture) for the full layout.
+
+## Commit convention
+
+Semantic Release with conventional commits:
+
+```
+<type>(<scope>): <description>
+```
+
+| Type | Release | Use for |
+|---|---|---|
+| `feat` | minor | New features |
+| `fix` | patch | Bug fixes |
+| `style` | patch | CSS / formatting |
+| `refactor` | patch | Restructuring without behaviour change |
+| `perf` | patch | Performance improvements |
+| `test` | patch | Tests |
+| `docs` | patch | Documentation |
+| `ci` | patch | CI/CD changes |
+| `chore` | none | Maintenance |
+
+`BREAKING CHANGE:` in the footer triggers a major release.
+
+## What CI checks
+
+Every PR to `main` runs:
+
+- ESLint
+- `npm run test:ci` with coverage gates
+- `npm audit --audit-level=high --omit=dev`
+- Trivy filesystem CVE scan (fails on HIGH / CRITICAL fixable issues)
+- Hadolint Dockerfile lint (threshold `error`)
+- CodeQL via GitHub's default Code Scanning setup
+
+Coverage reports are uploaded as a workflow artifact.
+
+## Releases
+
+- `release.yml` runs semantic-release on merge to `main`. It opens a release
+  PR with the version bump and changelog; once merged, it builds and pushes
+  the multi-arch image to `ghcr.io/gogorichielab/ppcollection` and tags the
+  GitHub release.
+- Maintainers don't tag by hand. Conventional commits drive the version.
+
+## Filing a good issue
+
+- Version (`docker inspect` or `/health`)
+- How you're running it (Docker run line, Compose file, behind a proxy?)
+- What you expected vs. what happened
+- Relevant lines from the container log (redact serials if you don't have
+  `AUDIT_VERBOSE` off)

--- a/wiki/FAQ.md
+++ b/wiki/FAQ.md
@@ -1,0 +1,99 @@
+# FAQ
+
+## Is my data sent anywhere?
+
+No. The app runs entirely on your machine, against a local SQLite file. The
+only outbound network call the app can make is the optional GitHub Releases
+update check, which is **off** by default and must be enabled with
+`UPDATE_CHECK=true`. There is no telemetry, no analytics, and no
+phone-home.
+
+## Where is my data stored?
+
+In `data/app.db` on the host. With the recommended Docker run line, that's
+`./data/app.db` in your current working directory at the time you ran the
+container. To back up your collection, back up that file. See
+[Operations → Backup and restore](Operations#backup-and-restore).
+
+## Can I run this without Docker?
+
+Yes — see [Installation → From source](Installation#from-source-contributors).
+Docker is the supported path, but a `node`-based install works too.
+
+## Why SQLite instead of Postgres / MySQL?
+
+SQLite fits the project's offline-first, single-operator model. One file is
+trivial to back up, restore, and version. There is no separate database
+process to run, secure, or upgrade. Postgres would add operational surface
+area without adding value for a personal inventory.
+
+## Can multiple people use the same instance?
+
+Not as of today. The auth model is a single local admin. Multi-user / RBAC
+is on the [roadmap](Home#project-links) but isn't built into the core app.
+A workaround is to run separate containers per user, each with their own
+data volume.
+
+## Can I host this on the public internet?
+
+You can, but always put it behind an HTTPS reverse proxy and set
+`TRUST_PROXY=true`. The auth model is built for a single trusted operator;
+exposing it directly to the internet without TLS or proxy-level
+authentication is not recommended. See [Security → Reverse
+proxy](Security#reverse-proxy).
+
+## Sessions aren't sticking when I log in behind nginx / Caddy / Traefik
+
+You almost certainly need `TRUST_PROXY=true`. Without it, Express sees the
+proxied request as plain HTTP, the browser refuses to send `Secure` cookies
+back, and your session is silently dropped on every request. See
+[Upgrading → v2.0.0](Upgrading#v200--secure-cookies-default-admin_password-required-for-first-run).
+
+## The app refuses to start with "SESSION_SECRET is required"
+
+Set `SESSION_SECRET` to a random 32-byte string:
+
+```bash
+SESSION_SECRET="$(openssl rand -hex 32)"
+```
+
+The production guard refuses to boot with the documented default. See
+[Security → Session secret guard](Security#session-secret-guard).
+
+## The app refuses to start with "ADMIN_PASSWORD must be changed"
+
+You're on a fresh install and `ADMIN_PASSWORD` is unset or `changeme`. Set a
+strong value before the first boot:
+
+```bash
+ADMIN_PASSWORD="$(openssl rand -base64 24)"
+```
+
+This only blocks brand-new installs — existing deployments with a hash
+already in `app.db` are unaffected.
+
+## I forgot the admin password
+
+Stop the container, then either:
+
+1. Restore an `app.db` backup taken before you lost the password, or
+2. Open `app.db` with the `sqlite3` CLI and delete the
+   `password_hash` row from the `settings` table, then start the app with
+   `ADMIN_PASSWORD` set — the app will re-seed and force a password change
+   on next login.
+
+## Can I import my existing inventory?
+
+Yes — the importer accepts CSV. Download the template from **Inventory →
+Import CSV**, fill it in, and upload. Disposition fields round-trip with
+the exporter.
+
+## Are there mobile apps?
+
+No. The web UI is responsive and works in mobile browsers. Inventory rows
+collapse into cards under 640px wide.
+
+## How do I report a bug or request a feature?
+
+Open an issue at <https://github.com/Gogorichielab/PPCollection/issues>.
+See [Contributing](Contributing) for guidelines.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,48 @@
+# Pew Pew Collection Wiki
+
+**Pew Pew Collection** is a self-hosted, offline-first web app for managing a
+personal firearm inventory. Your data lives on your machine — no cloud, no
+telemetry, no accounts beyond the single local admin user.
+
+This wiki is the long-form documentation for installing, configuring, securing,
+and operating the app. The repo [README](https://github.com/Gogorichielab/PPCollection/blob/main/README.md)
+keeps just the elevator pitch and a 60-second Docker quick start.
+
+---
+
+## Getting started
+
+- **[Installation](Installation)** — Docker, Docker Compose, and from-source
+  setups, plus the data volume layout and backup model.
+- **[Quick Start](Installation#docker-one-liner)** — copy/paste Docker command
+  to get running in under a minute.
+- **[First-run checklist](Installation#first-run-checklist)** — what the
+  app prompts you for the first time you log in.
+
+## Running it well
+
+- **[Configuration](Configuration)** — every environment variable, what it
+  does, and what changes between development and production defaults.
+- **[Security](Security)** — secure cookies, reverse-proxy guidance,
+  `TRUST_PROXY`, CSRF, rate limiting, and audit logs.
+- **[Operations](Operations)** — health probe, container healthcheck,
+  graceful shutdown, audit log format, and backup/restore.
+- **[Upgrading](Upgrading)** — version-specific upgrade notes, including the
+  v2.0.0 secure-cookies default and the v2.0.1 `SESSION_SECRET` guard.
+
+## Reference
+
+- **[Architecture](Architecture)** — the layered structure: routes →
+  controllers → services → repositories → SQLite.
+- **[Screenshots](Screenshots)** — full gallery of dashboard, inventory,
+  stats, insurance report, and the firearm detail view.
+- **[FAQ](FAQ)** — answers to the questions that come up most often.
+- **[Contributing](Contributing)** — how to file issues, propose changes,
+  and what the CI pipeline checks before a PR can land.
+
+## Project links
+
+- Source: <https://github.com/Gogorichielab/PPCollection>
+- Container image: `ghcr.io/gogorichielab/ppcollection`
+- Issues: <https://github.com/Gogorichielab/PPCollection/issues>
+- License: GNU GPL v3.0 or later

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,102 @@
+# Installation
+
+Pew Pew Collection ships as a multi-arch container image published to GHCR.
+Docker is the supported install path; the from-source workflow exists for
+contributors.
+
+## Docker (one-liner)
+
+```bash
+docker run -d \
+  --name ppcollection \
+  -p 3000:3000 \
+  -e SESSION_SECRET="$(openssl rand -hex 32)" \
+  -e ADMIN_USERNAME=admin \
+  -e ADMIN_PASSWORD=YourSecurePassword \
+  -v "$(pwd)/data:/data" \
+  --restart unless-stopped \
+  ghcr.io/gogorichielab/ppcollection:latest
+```
+
+Open <http://localhost:3000> and log in with the username and password you
+supplied. The app will force a password change before letting you continue.
+
+> **Your data lives in `./data/app.db` on the host.** The `-v "$(pwd)/data:/data"`
+> bind mount is what persists your inventory across container updates. Back up
+> the `data/` directory to back up your collection. `docker run` requires an
+> absolute host path — a bare `./data` is interpreted as an anonymous volume,
+> which Docker discards every time the container is recreated. If you prefer a
+> managed volume instead of a host directory, use `-v ppcollection_data:/data`.
+
+## Docker Compose
+
+```yaml
+services:
+  ppcollection:
+    image: ghcr.io/gogorichielab/ppcollection:latest
+    container_name: ppcollection
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      SESSION_SECRET: ${SESSION_SECRET}
+      ADMIN_USERNAME: admin
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
+    volumes:
+      - ./data:/data
+    stop_grace_period: 15s
+```
+
+Generate secrets and bring it up:
+
+```bash
+export SESSION_SECRET="$(openssl rand -hex 32)"
+export ADMIN_PASSWORD="$(openssl rand -base64 24)"
+docker compose up -d
+```
+
+## From source (contributors)
+
+Requires Node.js `>=20.0.0 <25.0.0`. The repo pins Node 20 via `.nvmrc`.
+
+```bash
+git clone https://github.com/Gogorichielab/PPCollection.git
+cd PPCollection
+nvm use            # picks up .nvmrc
+npm ci
+npm run dev        # or: npm start
+```
+
+The dev server runs at <http://localhost:3000>. The SQLite database is created
+at `./data/app.db` and migrations run automatically on boot.
+
+## First-run checklist
+
+1. The container or process must start with `SESSION_SECRET` and
+   `ADMIN_PASSWORD` set to non-default values when `NODE_ENV=production`. The
+   app refuses to boot otherwise — this is the [first-run guard](Security#first-run-guard).
+2. Log in with `ADMIN_USERNAME` / `ADMIN_PASSWORD`. The app immediately
+   redirects to `/change-password`.
+3. Set a new password (bcrypt cost 12). The `must_change_password` flag is
+   cleared and you land on the dashboard.
+4. From **Profile**, optionally change the username, toggle the theme, and
+   enable update notifications.
+
+## Reverse proxy
+
+If you put the app behind nginx, Caddy, or Traefik with HTTPS, set
+`TRUST_PROXY=true`. The [Security page](Security#reverse-proxy) covers the
+full reverse-proxy configuration matrix.
+
+## Backups
+
+The entire inventory lives in `data/app.db`. To back up:
+
+```bash
+docker exec ppcollection sqlite3 /data/app.db ".backup /data/app.db.bak"
+cp ./data/app.db.bak /your/backup/location/
+```
+
+A plain `cp` of the file works when the container is stopped. While the
+container is running, prefer the `.backup` form above so SQLite quiesces
+writes before copying.

--- a/wiki/Operations.md
+++ b/wiki/Operations.md
@@ -1,0 +1,115 @@
+# Operations
+
+How to run Pew Pew Collection in a way you can monitor, back up, and recover.
+
+## Health probe
+
+`GET /health` returns `200 { status, version, uptime }` without requiring
+authentication and is excluded from the request log. Use it from a reverse
+proxy, Docker `HEALTHCHECK`, or an external monitor like Uptime Kuma.
+
+```bash
+curl -s http://localhost:3000/health | jq
+```
+
+```json
+{
+  "status": "ok",
+  "version": "2.x.y",
+  "uptime": 1234.56
+}
+```
+
+## Container health
+
+The published image declares `HEALTHCHECK` against `/health`. Check the
+status with:
+
+```bash
+docker inspect --format '{{.State.Health.Status}}' ppcollection
+```
+
+It reports `healthy` once the HTTP server is serving requests.
+
+## Graceful shutdown
+
+The process traps `SIGTERM` and `SIGINT`, stops accepting new connections,
+drains in-flight requests, and closes the SQLite database before exiting.
+`docker compose` ships with a 15s `stop_grace_period`. Plain `docker stop`
+sends `SIGTERM` and waits 10s before `SIGKILL` — bump that with
+`docker stop -t 15` if you want headroom.
+
+## Audit logs
+
+Structured JSON log lines on stdout for:
+
+- `auth.login`
+- `auth.logout`
+- `auth.password_change`
+- `firearms.create`
+- `firearms.update`
+- `firearms.delete`
+- `firearms.import`
+
+Example:
+
+```json
+{"ts":"2026-05-31T18:42:01.234Z","event":"firearms.create","user":"[redacted]","firearm":"[redacted]"}
+```
+
+With `AUDIT_VERBOSE=true`, the `user` and `firearm` fields contain the
+username and serial. Keep it off unless you need the metadata in your log
+pipeline.
+
+Ship stdout to your log collector — `journalctl`, the Docker `json-file`
+driver, Loki, CloudWatch, etc.
+
+## Request logs
+
+`morgan` writes a one-line summary of every request to stdout, except for
+`GET /health`. Use a log driver to rotate / forward.
+
+## Backup and restore
+
+Everything is in `data/app.db`. To take a hot backup:
+
+```bash
+docker exec ppcollection sqlite3 /data/app.db ".backup /data/app.db.bak"
+cp ./data/app.db.bak /your/backup/location/
+```
+
+To restore:
+
+```bash
+docker stop ppcollection
+cp /your/backup/location/app.db.bak ./data/app.db
+docker start ppcollection
+```
+
+A plain `cp ./data/app.db /backup/...` while the container is stopped works
+just as well.
+
+## CSV export
+
+For a portable, human-readable snapshot, use the in-app CSV export
+(**Inventory → Export CSV**). The export round-trips with the importer and
+includes disposition fields.
+
+## Update check
+
+When `UPDATE_CHECK=true`, the app polls GitHub Releases once every 14 days
+and surfaces a banner if a newer tag is available. This is the only outbound
+call the app makes; it fails silently when offline. Off by default in line
+with the offline-first principle.
+
+## Resource footprint
+
+Pew Pew Collection is a single Node.js process with a SQLite file. Typical
+idle footprint:
+
+- Memory: ~60–120 MB RSS
+- CPU: idle near 0%
+- Disk: the database is on the order of KB per firearm, including history
+
+A Raspberry Pi 4 is more than enough hardware. The published image is
+multi-arch (`amd64`, `arm64`).

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,53 @@
+# Wiki sources
+
+This directory holds the source Markdown for the GitHub wiki at
+<https://github.com/Gogorichielab/PPCollection/wiki>.
+
+GitHub wikis live in a separate `.wiki.git` repo and aren't editable via the
+main repo's PR workflow, so the canonical copy on the wiki and the copy here
+have to be kept in sync by hand (or via a small script).
+
+## One-time setup
+
+```bash
+git clone https://github.com/Gogorichielab/PPCollection.wiki.git
+```
+
+## Publishing changes
+
+From the root of this repo:
+
+```bash
+WIKI=/path/to/PPCollection.wiki
+cp wiki/*.md "$WIKI/"
+cd "$WIKI"
+git add -A
+git commit -m "docs: sync wiki from main repo"
+git push origin master
+```
+
+GitHub renders changes to the wiki as soon as the push lands — there's no
+build step.
+
+## Pages
+
+- `Home.md` — landing page and navigation
+- `_Sidebar.md` — sidebar shown on every wiki page
+- `_Footer.md` — footer shown on every wiki page
+- `Installation.md` — Docker, Compose, and from-source setups
+- `Configuration.md` — environment variable reference
+- `Security.md` — auth, CSRF, rate limiting, reverse-proxy guidance
+- `Operations.md` — health probe, audit logs, backups
+- `Upgrading.md` — version-specific upgrade notes
+- `Architecture.md` — code layout and request lifecycle
+- `Screenshots.md` — gallery (uses `raw.githubusercontent.com` URLs)
+- `FAQ.md` — common questions and recovery procedures
+- `Contributing.md` — contributor-facing summary
+
+## Conventions
+
+- Cross-page links use the wiki page name only — e.g. `[Security](Security)`,
+  not a full URL. Anchor fragments use the lowercased, hyphenated heading.
+- Screenshots are linked via `raw.githubusercontent.com` so they render in
+  the wiki and survive renames here.
+- The sidebar is the canonical nav. Don't duplicate it inside every page.

--- a/wiki/Screenshots.md
+++ b/wiki/Screenshots.md
@@ -1,0 +1,51 @@
+# Screenshots
+
+All images live in the main repo under `docs/screenshots/` and are referenced
+here via `raw.githubusercontent.com` so they render in the wiki.
+
+## Dashboard
+
+![Dashboard](https://raw.githubusercontent.com/Gogorichielab/PPCollection/main/docs/screenshots/dashboard.png)
+
+Recent activity feed, type breakdown chart, and purchase-value-by-year chart.
+
+## Inventory
+
+![Inventory](https://raw.githubusercontent.com/Gogorichielab/PPCollection/main/docs/screenshots/inventory.png)
+
+Search, sort, filter by status / condition / type, and click any row to open
+the detail view. Rows collapse into cards on mobile.
+
+## Firearm detail
+
+![Firearm Detail](https://raw.githubusercontent.com/Gogorichielab/PPCollection/main/docs/screenshots/firearm-detail.png)
+
+Grouped fields, edit / duplicate / delete actions, and disposition data when
+applicable.
+
+## Add firearm
+
+![Add Firearm](https://raw.githubusercontent.com/Gogorichielab/PPCollection/main/docs/screenshots/add-firearm.png)
+
+The same form is used for edit; status changes drive which disposition fields
+are required.
+
+## Stats
+
+![Stats](https://raw.githubusercontent.com/Gogorichielab/PPCollection/main/docs/screenshots/stats.png)
+
+Collection summary, breakdown charts by type / caliber / make / condition,
+acquisition trends by month, average price by year, and disposition stats.
+
+## Insurance report
+
+![Insurance Report](https://raw.githubusercontent.com/Gogorichielab/PPCollection/main/docs/screenshots/insurance-report.png)
+
+Print-friendly inventory with total purchase value, suitable for policy
+documentation.
+
+## Profile
+
+![Profile](https://raw.githubusercontent.com/Gogorichielab/PPCollection/main/docs/screenshots/profile.png)
+
+Username, password change, theme toggle, and update-check preference.

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -1,0 +1,125 @@
+# Security
+
+Pew Pew Collection is designed for a single trusted operator running on
+hardware they control. The security model is centered on protecting the local
+admin session, not on multi-tenant isolation.
+
+## Authentication
+
+- **Bcrypt password hashing** at cost 12. `auth.service.js` uses
+  `bcrypt.compare` / `bcrypt.hash`. The plain `ADMIN_PASSWORD` env var is only
+  read on the very first boot to seed the hash.
+- **Forced password change on first login.** The `must_change_password` flag
+  is set when the hash is seeded; `requireAuth` redirects to
+  `/change-password` until cleared.
+- **Single admin user.** No registration flow, no public signups, no API keys.
+
+## First-run guard
+
+In production (`NODE_ENV=production`), the app refuses to start if:
+
+- `ADMIN_PASSWORD` is unset or equal to `changeme`, **and**
+- there is no existing password hash in `settings`.
+
+This prevents the default credential from ever shipping live. Once the admin
+hash exists in the database, subsequent restarts no longer need
+`ADMIN_PASSWORD` set.
+
+## Session secret guard
+
+The app refuses to start in production if `SESSION_SECRET` is unset or equals
+the documented default (`ppcollection_dev_secret`). Generate one with:
+
+```bash
+openssl rand -hex 32
+```
+
+## CSRF protection
+
+- `csrf-csrf` double-submit cookie pattern. Token is set in a cookie and
+  surfaced to templates as `res.locals.csrfToken`.
+- Every state-changing form embeds the token in a hidden input; rejected
+  requests render `errors/403.ejs`.
+
+## Rate limiting
+
+`express-rate-limit` is applied on:
+
+| Endpoint | Limit |
+|---|---|
+| `POST /login` (failed only) | 10 per 15 min per IP |
+| `POST /change-password` | 20 per 15 min per IP |
+
+Successful logins do not count against the limit.
+
+## Cookies
+
+| Flag | Value |
+|---|---|
+| `httpOnly` | always |
+| `sameSite` | `lax` |
+| `Secure` | `true` when `NODE_ENV=production` (or when `SECURE_COOKIES=true`) |
+
+## Reverse proxy
+
+If you put the app behind nginx, Caddy, or Traefik with HTTPS:
+
+| Your setup | What to set |
+|---|---|
+| HTTPS reverse proxy in front of the app | `TRUST_PROXY=true` |
+| Plain HTTP in production (no TLS terminator) | `SECURE_COOKIES=false` |
+| Both `NODE_ENV=production` and a TLS proxy | `TRUST_PROXY=true` and accept the default `SECURE_COOKIES=true` |
+| Local dev at `http://localhost:3000` | Nothing — defaults are correct |
+
+Without `TRUST_PROXY=true`, Express will see the proxied request as plain
+HTTP, browsers will refuse to send the `Secure` cookie back, and sessions
+will silently fail to persist.
+
+### Example: nginx
+
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP $remote_addr;
+}
+```
+
+Pair with `TRUST_PROXY=true` on the app side.
+
+## HTTP hardening
+
+- `helmet` middleware with the default Content Security Policy enabled.
+- `method-override` only honors the `_method` hidden form field — no query
+  string overrides.
+- Request logging via `morgan`; the `/health` endpoint is excluded.
+
+## Audit logs
+
+Login, logout, password change, and firearm create/update/delete/import events
+are emitted as structured JSON on stdout. By default, usernames and serials
+are redacted; set `AUDIT_VERBOSE=true` if you need them in the log.
+
+Ship the container's stdout to your host log collector — `journalctl`, the
+Docker `json-file` driver, Loki, etc.
+
+## Input validation
+
+`firearms.validators.js` enforces field length limits and numeric bounds
+before anything reaches the repository layer. The repository layer is SQL only
+and uses parameterized queries throughout. The `serial` column has a
+database-level `UNIQUE` constraint, enforced for both form submission and CSV
+import.
+
+## What's intentionally out of scope
+
+- Multi-user / role-based access control. Premium SaaS-style features are
+  noted in the roadmap but not built into the core app.
+- Network-level isolation. Run the app on a private network or behind a
+  reverse proxy with auth in front if you want defense in depth.
+- Encryption at rest. SQLite is plain on disk — encrypt the host volume if you
+  need that.
+
+See also: [Configuration](Configuration), [Upgrading](Upgrading).

--- a/wiki/Upgrading.md
+++ b/wiki/Upgrading.md
@@ -1,0 +1,88 @@
+# Upgrading
+
+Pew Pew Collection follows semantic versioning. Patch releases are always safe
+to take as a drop-in image swap. Minor releases never remove features. Major
+releases call out breaking changes here.
+
+## Standard upgrade (Docker)
+
+```bash
+docker pull ghcr.io/gogorichielab/ppcollection:latest
+docker stop ppcollection
+docker rm ppcollection
+# re-run your original `docker run` (the volume keeps your data)
+```
+
+If you use Docker Compose:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Migrations run automatically on boot. The `schema_migrations` table records
+which files have been applied; never modify or rename a migration that has
+shipped.
+
+## Existing deployments
+
+Existing deployments continue to work without configuration changes. The
+v2.x guards only affect **new installations** that have never seeded an admin
+account. If you've been running the app, your account hash is already stored
+in `app.db` and no action is required.
+
+## Version-specific notes
+
+### v2.0.1 — `SESSION_SECRET` required in production
+
+The app refuses to start if `SESSION_SECRET` is unset or matches the
+hard-coded default. Generate one with:
+
+```bash
+SESSION_SECRET="$(openssl rand -hex 32)"
+```
+
+### v2.0.0 — Secure cookies default; `ADMIN_PASSWORD` required for first-run
+
+**Secure cookies.** Session and CSRF cookies now have the `Secure` flag
+enabled by default when `NODE_ENV=production`. The published Docker image
+always sets that. Before v2.0.0 the flag was opt-in.
+
+| If you run the app... | What you need to do |
+|---|---|
+| Behind an HTTPS reverse proxy with `TRUST_PROXY=true` | Nothing. |
+| Behind an HTTPS reverse proxy without `TRUST_PROXY` | Set `TRUST_PROXY=true` so Express honors the `X-Forwarded-Proto` header. |
+| On plain HTTP in production (no TLS) | Add `SECURE_COOKIES=false` to restore plain cookies; otherwise sessions silently fail. |
+| Locally (any non-production `NODE_ENV`) | No change. Default is still off. |
+
+**`ADMIN_PASSWORD` required for first-run.** The app refuses to start on a
+fresh install if `ADMIN_PASSWORD` is unset or `changeme`. Set a strong value
+before the first boot:
+
+```bash
+ADMIN_PASSWORD="$(openssl rand -base64 24)"
+```
+
+This only applies to brand-new installs. Existing deployments with a hash
+already in the database are unaffected.
+
+## Backups before upgrading
+
+```bash
+docker exec ppcollection sqlite3 /data/app.db ".backup /data/app.db.bak"
+cp ./data/app.db.bak /your/backup/location/
+```
+
+A patch upgrade should not need a rollback, but the database file is small
+and the cost of a snapshot is near zero.
+
+## Rolling back
+
+Pin to the previous tag and redeploy:
+
+```bash
+docker pull ghcr.io/gogorichielab/ppcollection:vX.Y.Z
+```
+
+Schema migrations are forward-only. If you need to roll back across a
+migration boundary, restore your pre-upgrade `app.db` from a snapshot.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,2 @@
+Pew Pew Collection · Self-hosted, offline-first firearm inventory ·
+[GPL-3.0-or-later](https://github.com/Gogorichielab/PPCollection/blob/main/LICENSE)

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,21 @@
+**[Home](Home)**
+
+**Getting started**
+- [Installation](Installation)
+- [Configuration](Configuration)
+
+**Running it**
+- [Security](Security)
+- [Operations](Operations)
+- [Upgrading](Upgrading)
+
+**Reference**
+- [Architecture](Architecture)
+- [Screenshots](Screenshots)
+- [FAQ](FAQ)
+- [Contributing](Contributing)
+
+---
+
+[Source on GitHub](https://github.com/Gogorichielab/PPCollection) ·
+[Report an issue](https://github.com/Gogorichielab/PPCollection/issues)


### PR DESCRIPTION
## Summary

- Trims `README.md` to a tagline, hero screenshot, feature bullets, 60-second Docker quick start, and links into the wiki for the long-form material. The Configuration table, Security Notes, Upgrading guidance, Operations section, and screenshot gallery are all gone from the README.
- Adds `wiki/` with the source markdown for the new wiki pages, plus a sync `wiki/README.md` explaining how to push them to `PPCollection.wiki.git` (since the wiki repo isn't reachable from this CI environment).

## Wiki pages added

- `Home.md` + `_Sidebar.md` + `_Footer.md` — landing page and chrome
- `Installation.md` — Docker, Docker Compose, from-source
- `Configuration.md` — full env var reference + prod/dev defaults
- `Security.md` — auth, CSRF, rate limiting, secure cookies, reverse-proxy matrix, audit logs
- `Operations.md` — `/health`, container HEALTHCHECK, graceful shutdown, backup/restore, resource footprint
- `Upgrading.md` — standard upgrade flow + v2.0.0 / v2.0.1 notes
- `Architecture.md` — layered structure, request lifecycle, stack table
- `Screenshots.md` — gallery via `raw.githubusercontent.com` URLs
- `FAQ.md` — common questions and recovery procedures
- `Contributing.md` — higher-level overview that links to `CONTRIBUTING.md`

## Publishing the wiki

The wiki repo (`PPCollection.wiki.git`) isn't reachable from the CI environment, so the pages can't be pushed from here. Once this PR is merged (or from a local clone of this branch):

```bash
git clone https://github.com/Gogorichielab/PPCollection.wiki.git ../PPCollection.wiki
cp wiki/*.md ../PPCollection.wiki/
cd ../PPCollection.wiki
git add -A
git commit -m "docs: sync wiki from main repo"
git push origin master
```

Subsequent updates follow the same pattern; the steps are documented in `wiki/README.md`.

## Test plan

- [ ] README renders cleanly on github.com/Gogorichielab/PPCollection (hero screenshot, badges, Quick Start, wiki links)
- [ ] Wiki Quick Start command still works against `ghcr.io/gogorichielab/ppcollection:latest`
- [ ] After publishing, wiki internal links resolve (Home → Installation/Configuration/Security/Operations/Upgrading/Architecture/Screenshots/FAQ/Contributing)
- [ ] Sidebar and footer render on every wiki page
- [ ] Screenshot URLs (`raw.githubusercontent.com/.../main/docs/screenshots/*.png`) load in the wiki

https://claude.ai/code/session_01Q6AXKbpvNSxqg4uLcDwtCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q6AXKbpvNSxqg4uLcDwtCV)_