### PR TITLE
docs(docker): clarify data mount reuse during updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Open `http://localhost:3000`. On first login you will be prompted to change the 
 > host path here — a bare `./data` is interpreted as an anonymous volume, which
 > Docker discards every time the container is recreated. If you prefer a managed
 > volume instead of a host directory, use `-v ppcollection_data:/data`.
+>
+> **Important when updating:** reuse the exact same host directory or named
+> volume every time you recreate the container. If the app asks you to change the
+> initial admin password again after an update, it is almost always running
+> against a new empty `/data` mount instead of your existing `app.db`. Stop the
+> container and restore the previous mount before adding new records.
 
 ## Configuration
 
@@ -116,6 +122,26 @@ unset or `changeme`. Set a strong value before the first start:
 ```bash
 ADMIN_PASSWORD="$(openssl rand -base64 24)"
 ```
+
+### Docker update data check
+
+If an updated container looks like a brand-new install, do **not** complete the
+first-run password flow or add new inventory yet. That means the container is
+not seeing the same SQLite file it used before the update. Check the active
+mount and database file first:
+
+```bash
+docker inspect ppcollection --format '{{range .Mounts}}{{println .Source "->" .Destination}}{{end}}'
+ls -lh ./data/app.db
+```
+
+For Docker Compose, run updates from the same directory that owns the original
+`./data` folder, or change the compose file to an absolute bind mount such as
+`/srv/ppcollection/data:/data`. For `docker run`, always reuse the same
+absolute bind mount (`-v /srv/ppcollection/data:/data`) or the same named volume
+(`-v ppcollection_data:/data`). Recreating the container without that mount
+creates a fresh database at `/data/app.db`, which makes the app correctly behave
+like a first-time install.
 
 ## Operations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,11 @@ services:
       start_period: 15s
       retries: 3
     volumes:
+      # Persist the SQLite database across image updates. Keep this host path
+      # stable; changing the compose project directory points ./data at a new
+      # empty folder and makes the app look like a first-time install. Use an
+      # absolute path (for example /srv/ppcollection/data:/data) if you update
+      # from multiple directories or automation tools.
       - ./data:/data
     # Resource governance — sized for a single-user Express + SQLite workload.
     # Tune in docker-compose.override.yml if you run on a Pi or a busier host.

--- a/docs/index.html
+++ b/docs/index.html
@@ -294,6 +294,10 @@
       overflow: hidden;
     }
 
+    .code-block-spaced {
+      margin-top: 1.5rem;
+    }
+
     .code-header {
       display: flex;
       align-items: center;
@@ -766,6 +770,13 @@
             <p>Add your first firearm. All data lives in a single <code>app.db</code> SQLite file — easy to back up, easy to restore.</p>
           </div>
         </div>
+        <div class="step">
+          <div class="step-num">05</div>
+          <div class="step-body">
+            <h3>Update safely</h3>
+            <p>Always recreate the container with the same <code>/data</code> bind mount or named volume. If an update asks for the first-run password change again, stop and fix the mount before adding records.</p>
+          </div>
+        </div>
         <div style="margin-top:1rem;">
           <a href="https://github.com/Gogorichielab/PPCollection#configuration" class="btn btn-ghost">→ Full configuration docs</a>
         </div>
@@ -842,6 +853,13 @@
           </tr>
         </tbody>
       </table>
+    </div>
+    <div class="code-block code-block-spaced">
+      <h3>Docker update data check</h3>
+      <p>If an updated container looks like a new install, do not complete first-run setup yet. Confirm the container still mounts the original data directory:</p>
+      <pre><span class="ck">docker</span> <span class="cv">inspect</span> <span class="ca">ppcollection</span> --format <span class="cv">'{{range .Mounts}}{{println .Source "-&gt;" .Destination}}{{end}}'</span>
+<span class="ck">ls</span> <span class="ca">-lh ./data/app.db</span></pre>
+      <p>For Compose, run updates from the same directory that owns <code>./data</code>, or use an absolute bind mount such as <code>/srv/ppcollection/data:/data</code>. A changed mount gives the app a fresh <code>/data/app.db</code>, so it correctly behaves like a first-time install.</p>
     </div>
   </section>
 


### PR DESCRIPTION
### Motivation
- Users updating the Docker container reported the app behaving like a first-time install because the container no longer saw the existing SQLite database at `/data/app.db`.
- The change aims to reduce accidental data loss or duplicate first-run setup by helping operators confirm the container is mounting the same host data directory after an update.
- This is a documentation and UX safeguard only; no runtime behavior or security guards were altered.

### Description
- Add a README warning that repeated first-run prompts after an update usually indicate the container is using a new empty `/data` mount instead of the original `app.db` and advise stopping before completing first-run setup.
- Add troubleshooting commands to the README to inspect active Docker mounts and verify the host `./data/app.db` file exists (`docker inspect ...` and `ls -lh ./data/app.db`).
- Add comments to `docker-compose.yml` recommending a stable or absolute bind mount for `./data:/data` so Compose updates don’t point at a different host directory.
- Update the static docs site (`docs/index.html`) with an “Update safely” step and a spaced code block containing the same diagnostic guidance, and add a small `.code-block-spaced` style to maintain layout spacing.

### Testing
- Ran `npm run lint` (ESLint) against `src` and `tests`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24716bef788332bb0f17db50552b34)