### PR TITLE
docs: add wiki sync workflow and helper script

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,0 +1,55 @@
+name: Sync wiki
+
+# Mirrors the Markdown sources in wiki/ to the GitHub wiki repo
+# (PPCollection.wiki.git) whenever they change on main. wiki/ is the single
+# source of truth; pages edited in the wiki UI are overwritten on the next run.
+#
+# Requires a repo secret WIKI_TOKEN: a Personal Access Token (classic, `repo`
+# scope, or a fine-grained token with Contents: write). The default
+# GITHUB_TOKEN cannot push to *.wiki.git repos.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'wiki/**'
+      - '.github/workflows/wiki-sync.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wiki-sync
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Clone wiki and mirror sources
+        env:
+          WIKI_TOKEN: ${{ secrets.WIKI_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${WIKI_TOKEN:-}" ]; then
+            echo "::error::WIKI_TOKEN secret is not set; cannot push to the wiki repo." >&2
+            exit 1
+          fi
+          git clone \
+            "https://x-access-token:${WIKI_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" \
+            wiki-repo
+          rsync -a --delete --exclude='.git' wiki/ wiki-repo/
+          cd wiki-repo
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "Wiki already up to date — nothing to push."
+            exit 0
+          fi
+          git commit -m "docs: sync wiki from ${GITHUB_SHA}"
+          git push origin HEAD:master

--- a/scripts/sync-wiki.sh
+++ b/scripts/sync-wiki.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Sync the Markdown sources in wiki/ to the GitHub wiki repo.
+#
+# The GitHub wiki lives in a separate repo (PPCollection.wiki.git) with no PR
+# workflow, so wiki/ in this repo is the single source of truth and this script
+# mirrors it across. wiki/ wins: pages edited directly in the wiki UI that no
+# longer exist here will be removed (rsync --delete).
+#
+# Usage:
+#   scripts/sync-wiki.sh                 # clones the wiki to a temp dir and pushes
+#   WIKI=/path/to/PPCollection.wiki scripts/sync-wiki.sh   # reuse a local clone
+#
+set -euo pipefail
+
+REPO_URL="https://github.com/Gogorichielab/PPCollection.wiki.git"
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/wiki"
+
+if [ ! -d "$SRC_DIR" ]; then
+  echo "error: source wiki/ directory not found at $SRC_DIR" >&2
+  exit 1
+fi
+
+CLEANUP=""
+if [ -n "${WIKI:-}" ]; then
+  WIKI_DIR="$WIKI"
+  if [ ! -d "$WIKI_DIR/.git" ]; then
+    echo "error: \$WIKI ($WIKI_DIR) is not a git clone of the wiki" >&2
+    exit 1
+  fi
+  git -C "$WIKI_DIR" pull --ff-only
+else
+  WIKI_DIR="$(mktemp -d)"
+  CLEANUP="$WIKI_DIR"
+  trap '[ -n "$CLEANUP" ] && rm -rf "$CLEANUP"' EXIT
+  echo "Cloning $REPO_URL ..."
+  git clone --depth 1 "$REPO_URL" "$WIKI_DIR"
+fi
+
+rsync -a --delete --exclude='.git' "$SRC_DIR"/ "$WIKI_DIR"/
+
+cd "$WIKI_DIR"
+if git diff --quiet && git diff --cached --quiet; then
+  echo "Wiki already up to date — nothing to push."
+  exit 0
+fi
+
+git add -A
+git commit -m "docs: sync wiki from main repo"
+# GitHub wiki repos use the 'master' default branch.
+git push origin HEAD:master
+echo "Wiki synced."

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -4,30 +4,38 @@ This directory holds the source Markdown for the GitHub wiki at
 <https://github.com/Gogorichielab/PPCollection/wiki>.
 
 GitHub wikis live in a separate `.wiki.git` repo and aren't editable via the
-main repo's PR workflow, so the canonical copy on the wiki and the copy here
-have to be kept in sync by hand (or via a small script).
+main repo's PR workflow. This directory is the **single source of truth** — the
+copy on the wiki is mirrored from here. Pages edited directly in the wiki UI are
+overwritten on the next sync, so always make changes in `wiki/`.
 
-## One-time setup
+## Automated sync (recommended)
+
+`.github/workflows/wiki-sync.yml` pushes `wiki/**` to the wiki repo on every
+change merged to `main`, and can be run manually from the Actions tab.
+
+It needs a repo secret named `WIKI_TOKEN` — a Personal Access Token with `repo`
+scope (or a fine-grained token with **Contents: write**). The default
+`GITHUB_TOKEN` cannot push to `*.wiki.git` repos, which is why a PAT is
+required. Add it under **Settings → Secrets and variables → Actions**.
+
+## Manual sync
+
+Run the helper from the repo root — it clones the wiki, mirrors `wiki/`, and
+pushes:
 
 ```bash
-git clone https://github.com/Gogorichielab/PPCollection.wiki.git
+scripts/sync-wiki.sh
 ```
 
-## Publishing changes
-
-From the root of this repo:
+To reuse an existing local clone instead of cloning each time:
 
 ```bash
-WIKI=/path/to/PPCollection.wiki
-cp wiki/*.md "$WIKI/"
-cd "$WIKI"
-git add -A
-git commit -m "docs: sync wiki from main repo"
-git push origin master
+WIKI=/path/to/PPCollection.wiki scripts/sync-wiki.sh
 ```
 
-GitHub renders changes to the wiki as soon as the push lands — there's no
-build step.
+Both the script and the workflow use `rsync --delete`, so removing a file from
+`wiki/` also removes that page from the wiki. GitHub renders changes as soon as
+the push lands — there's no build step.
 
 ## Pages
 


### PR DESCRIPTION
## What

Adds tooling to sync the `wiki/` Markdown sources to the separate GitHub wiki repo (`PPCollection.wiki.git`). Previously this was a hand-run `cp` + `git push` documented in `wiki/README.md`.

## Changes

- **`.github/workflows/wiki-sync.yml`** — pushes `wiki/**` to the wiki repo on every change merged to `main`; also runs via `workflow_dispatch`. Mirrors with `rsync --delete` (repo is source of truth).
- **`scripts/sync-wiki.sh`** — manual one-shot sync (clones the wiki, mirrors `wiki/`, pushes). Honors `$WIKI` to reuse an existing local clone.
- **`wiki/README.md`** — documents both paths and the source-of-truth convention.

## One-time setup required

The workflow needs a repo secret **`WIKI_TOKEN`** — a PAT with `repo` scope (or fine-grained with Contents: write). GitHub's default `GITHUB_TOKEN` cannot push to `*.wiki.git` repos, which is the reason a PAT is needed. Add it under **Settings → Secrets and variables → Actions**.

## Notes

- Sync is **one-way (repo → wiki)**. Pages edited in the wiki UI are overwritten on the next run.
- `--delete` means removing a file from `wiki/` removes the page from the wiki.

https://claude.ai/code/session_01L2mTfGeH3NXXfTKKBiW8oS

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2mTfGeH3NXXfTKKBiW8oS)_