### PR TITLE
ci: gate and sign container releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ permissions:
   pull-requests: write
   packages: write
   pages: write
+  security-events: write
   id-token: write
 
 jobs:
@@ -248,11 +249,15 @@ jobs:
           fi
 
   docker:
-    name: Build & Push Docker Image
+    name: Scan, Build & Push Docker Image
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: publish
     if: needs.publish.outputs.new_release_published == 'true'
+
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+      image_ref: ${{ steps.image_ref.outputs.ref }}
 
     steps:
       - name: Checkout release tag
@@ -284,9 +289,38 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=v${{ needs.publish.outputs.new_release_version }}
             type=semver,pattern={{major}},value=v${{ needs.publish.outputs.new_release_version }}
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push Docker image
+      - name: Build local release candidate
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          platforms: linux/amd64
+          tags: ppcollection:release-candidate
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Trivy - scan built image
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: ppcollection:release-candidate
+          format: sarif
+          output: trivy-image-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+          ignore-unfixed: true
+          cache: true
+
+      - name: Upload Trivy image SARIF results
+        if: always() && hashFiles('trivy-image-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-image-results.sarif
+          category: trivy-image
+
+      - name: Build and push versioned Docker image
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -316,6 +350,112 @@ jobs:
         with:
           tag_name: v${{ needs.publish.outputs.new_release_version }}
           files: sbom.cdx.json
+
+  smoke:
+    name: Smoke Test Built Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - publish
+      - docker
+    if: needs.publish.outputs.new_release_published == 'true'
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: v${{ needs.publish.outputs.new_release_version }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull built image
+        run: docker pull "${{ needs.docker.outputs.image_ref }}"
+
+      - name: Start release candidate
+        env:
+          IMAGE_REF: ${{ needs.docker.outputs.image_ref }}
+        run: |
+          SMOKE_INITIAL_PASSWORD=$(openssl rand -base64 24)
+          SMOKE_SESSION_SECRET=$(openssl rand -hex 32)
+          echo "::add-mask::$SMOKE_INITIAL_PASSWORD"
+          echo "::add-mask::$SMOKE_SESSION_SECRET"
+          echo "SMOKE_INITIAL_PASSWORD=$SMOKE_INITIAL_PASSWORD" >> "$GITHUB_ENV"
+          docker run --detach --name ppcollection-smoke \
+            --publish 3000:3000 \
+            --env ADMIN_USERNAME=smoke-admin \
+            --env ADMIN_PASSWORD="$SMOKE_INITIAL_PASSWORD" \
+            --env SESSION_SECRET="$SMOKE_SESSION_SECRET" \
+            --env SECURE_COOKIES=false \
+            "$IMAGE_REF"
+
+      - name: Wait for health endpoint
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:3000/health; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs ppcollection-smoke
+          exit 1
+
+      - name: Exercise login and firearm CRUD
+        run: ./scripts/smoke.sh http://127.0.0.1:3000 smoke-admin "$SMOKE_INITIAL_PASSWORD"
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker logs ppcollection-smoke || true
+
+      - name: Tear down release candidate
+        if: always()
+        run: docker rm --force ppcollection-smoke 2>/dev/null || true
+
+  promote:
+    name: Promote & Sign Docker Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs:
+      - publish
+      - docker
+      - smoke
+    if: needs.publish.outputs.new_release_published == 'true'
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Compute lowercase image name
+        id: image
+        env:
+          REPOSITORY: ${{ github.repository }}
+        run: echo "name=ghcr.io/${REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign image digest with GitHub OIDC
+        env:
+          DIGEST: ${{ needs.docker.outputs.digest }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+        run: cosign sign --yes "${IMAGE_NAME}@${DIGEST}"
+
+      - name: Promote signed and tested image to latest
+        env:
+          DIGEST: ${{ needs.docker.outputs.digest }}
+          IMAGE_NAME: ${{ steps.image.outputs.name }}
+        run: docker buildx imagetools create --tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}@${DIGEST}"
 
   pages:
     name: Deploy GitHub Pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,7 +405,7 @@ jobs:
           exit 1
 
       - name: Exercise login and firearm CRUD
-        run: ./scripts/smoke.sh http://127.0.0.1:3000 smoke-admin "$SMOKE_INITIAL_PASSWORD"
+        run: bash ./scripts/smoke.sh http://127.0.0.1:3000 smoke-admin "$SMOKE_INITIAL_PASSWORD"
 
       - name: Show container logs on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ Full docs live in the [wiki](https://github.com/Gogorichielab/PPCollection/wiki)
 - **[Screenshots](https://github.com/Gogorichielab/PPCollection/wiki/Screenshots)** — full gallery
 - **[FAQ](https://github.com/Gogorichielab/PPCollection/wiki/FAQ)** — common questions and recovery procedures
 
+## Verifying releases
+
+Release images are scanned before publication, exercised through an end-to-end
+login and inventory flow, and signed keylessly with Sigstore. Install
+[cosign](https://docs.sigstore.dev/cosign/system_config/installation/) and verify
+the image before deployment:
+
+```bash
+cosign verify ghcr.io/gogorichielab/ppcollection:latest \
+  --certificate-identity-regexp 'https://github.com/Gogorichielab/PPCollection/.github/workflows/release.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+Successful verification confirms that the image was signed by this repository's
+release workflow. Pin a version tag or digest for reproducible deployments.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and the

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASE_URL="${1:-http://127.0.0.1:3000}"
+USERNAME="${2:-admin}"
+CURRENT_PASSWORD="${3:-}"
+NEW_PASSWORD="${SMOKE_NEW_PASSWORD:-PpcollectionSmoke!2026}"
+
+if [[ -z "$CURRENT_PASSWORD" ]]; then
+  echo "usage: $0 [base-url] [username] <initial-password>" >&2
+  exit 2
+fi
+
+WORK_DIR=$(mktemp -d)
+COOKIE_JAR="$WORK_DIR/cookies.txt"
+BODY_FILE="$WORK_DIR/body.html"
+HEADER_FILE="$WORK_DIR/headers.txt"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+touch "$COOKIE_JAR"
+
+request() {
+  curl --silent --show-error \
+    --cookie "$COOKIE_JAR" \
+    --cookie-jar "$COOKIE_JAR" \
+    --dump-header "$HEADER_FILE" \
+    --output "$BODY_FILE" \
+    --write-out '%{http_code}' \
+    "$@"
+}
+
+expect_status() {
+  local expected=$1
+  local actual=$2
+  local action=$3
+
+  if [[ "$actual" != "$expected" ]]; then
+    echo "$action returned HTTP $actual; expected $expected" >&2
+    sed -n '1,30p' "$HEADER_FILE" >&2
+    sed -n '1,80p' "$BODY_FILE" >&2
+    exit 1
+  fi
+}
+
+expect_location() {
+  local expected=$1
+  local actual
+
+  actual=$(redirect_location)
+  if [[ ! "$actual" =~ $expected ]]; then
+    echo "redirect location '$actual' did not match '$expected'" >&2
+    exit 1
+  fi
+}
+
+redirect_location() {
+  awk '
+    tolower($1) == "location:" {
+      $1 = ""
+      sub(/^[[:space:]]+/, "")
+      sub(/\r$/, "")
+      print
+      exit
+    }
+  ' "$HEADER_FILE"
+}
+
+csrf_token() {
+  local token
+
+  token=$(awk '
+    /name="_csrf" value="/ {
+      sub(/^.*name="_csrf" value="/, "")
+      sub(/".*$/, "")
+      print
+      exit
+    }
+  ' "$BODY_FILE")
+  if [[ -z "$token" ]]; then
+    echo "response did not contain a CSRF token" >&2
+    exit 1
+  fi
+  printf '%s' "$token"
+}
+
+status=$(request "$BASE_URL/health")
+expect_status 200 "$status" "health check"
+grep -q '"status":"ok"' "$BODY_FILE"
+
+status=$(request "$BASE_URL/login")
+expect_status 200 "$status" "login page"
+token=$(csrf_token)
+
+status=$(request \
+  --request POST \
+  --data-urlencode "_csrf=$token" \
+  --data-urlencode "username=$USERNAME" \
+  --data-urlencode "password=$CURRENT_PASSWORD" \
+  "$BASE_URL/login")
+expect_status 302 "$status" "login"
+expect_location '^/change-password$'
+
+status=$(request "$BASE_URL/change-password")
+expect_status 200 "$status" "change-password page"
+token=$(csrf_token)
+
+status=$(request \
+  --request POST \
+  --data-urlencode "_csrf=$token" \
+  --data-urlencode "current_password=$CURRENT_PASSWORD" \
+  --data-urlencode "new_password=$NEW_PASSWORD" \
+  --data-urlencode "confirm_password=$NEW_PASSWORD" \
+  "$BASE_URL/change-password")
+expect_status 302 "$status" "password change"
+expect_location '^/$'
+
+status=$(request "$BASE_URL/firearms/new")
+expect_status 200 "$status" "new firearm page"
+token=$(csrf_token)
+serial="SMOKE-$(date +%s)-$$"
+
+status=$(request \
+  --request POST \
+  --data-urlencode "_csrf=$token" \
+  --data-urlencode 'make=Smoke Test' \
+  --data-urlencode 'model=Release Candidate' \
+  --data-urlencode "serial=$serial" \
+  --data-urlencode 'caliber=9mm' \
+  --data-urlencode 'status=Active' \
+  --data-urlencode 'firearm_type=Pistol' \
+  "$BASE_URL/firearms")
+expect_status 302 "$status" "firearm creation"
+expect_location '^/firearms/[0-9]+$'
+firearm_path=$(redirect_location)
+
+status=$(request "$BASE_URL$firearm_path")
+expect_status 200 "$status" "firearm detail"
+grep -q 'Release Candidate' "$BODY_FILE"
+
+status=$(request "$BASE_URL$firearm_path/edit")
+expect_status 200 "$status" "edit firearm page"
+token=$(csrf_token)
+
+status=$(request \
+  --request POST \
+  --data-urlencode "_csrf=$token" \
+  --data-urlencode 'make=Smoke Test' \
+  --data-urlencode 'model=Verified Candidate' \
+  --data-urlencode "serial=$serial" \
+  --data-urlencode 'caliber=9mm' \
+  --data-urlencode 'status=Active' \
+  --data-urlencode 'firearm_type=Pistol' \
+  "$BASE_URL$firearm_path?_method=PUT")
+expect_status 302 "$status" "firearm update"
+expect_location "^${firearm_path}$"
+
+status=$(request "$BASE_URL$firearm_path")
+expect_status 200 "$status" "updated firearm detail"
+grep -q 'Verified Candidate' "$BODY_FILE"
+token=$(csrf_token)
+
+status=$(request \
+  --request POST \
+  --data-urlencode "_csrf=$token" \
+  "$BASE_URL$firearm_path/delete")
+expect_status 302 "$status" "firearm deletion"
+expect_location '^/firearms$'
+
+status=$(request "$BASE_URL$firearm_path")
+expect_status 404 "$status" "deleted firearm lookup"
+
+echo "Smoke test passed: health, login, password change, and firearm CRUD"


### PR DESCRIPTION
## Summary

- build and scan a local release candidate before publishing versioned multi-arch images
- upload Trivy image findings to code scanning and fail on fixable HIGH/CRITICAL vulnerabilities
- run the published image through health, authentication, forced password change, and firearm CRUD checks
- sign the tested manifest digest with GitHub OIDC before promoting it to `latest`
- document end-user verification with cosign

## Validation

- `npm run lint`
- `npm run test:ci` (18 suites, 177 tests)
- `npm audit --audit-level=high --omit=dev` (0 vulnerabilities)
- `bash -n scripts/smoke.sh`
- parsed `.github/workflows/release.yml`
- ran `scripts/smoke.sh` against a production-mode local server

Docker is not installed in the local workspace, so the actual image build, Trivy image scan, multi-arch push, and keyless signing remain workflow-level checks.

Closes #432
Closes #429
Closes #425