### PR TITLE
feat: add structured request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,30 @@ cosign verify ghcr.io/gogorichielab/ppcollection:latest \
 Successful verification confirms that the image was signed by this repository's
 release workflow. Pin a version tag or digest for reproducible deployments.
 
+## Structured logs
+
+Application-generated logs in production deployments, including the Docker
+image, emit one JSON object per line to stdout or stderr. This works directly
+with `docker logs`, journald, Loki, Vector, and other collectors. HTTP access
+records use this schema:
+
+| Field | Description |
+| --- | --- |
+| `ts` | ISO 8601 timestamp |
+| `level` | `info`, `warn`, or `error` |
+| `event` | Stable event name, such as `http.request` or `login.success` |
+| `id` | Correlation ID shared by the response, access log, and related audit events |
+| `method`, `url`, `status` | HTTP request and response details |
+| `durationMs`, `contentLength` | Response timing and size when available |
+| `remoteAddress`, `userAgent` | Request source metadata |
+
+Clients may send an `X-Request-ID` header containing 1-128 letters, numbers,
+periods, underscores, colons, or hyphens. Valid values are returned unchanged in
+the response header; missing or invalid values are replaced with a UUID. Health
+requests return a correlation header but are omitted from access logs to avoid
+probe noise. Audit logs redact usernames and serial numbers unless
+`AUDIT_VERBOSE=true`.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) and the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -213,4 +213,4 @@ The service layer (`firearms.service.js`) additionally validates uniqueness befo
 
 ## Audit logging
 
-Auth and inventory mutations emit structured JSON events through `src/services/audit.service.js` (`login.success`, `login.failure`, `logout`, `firearm.create`, `firearm.update`, `firearm.delete`, `firearm.import`, etc.). By default, username and serial fields are redacted unless `AUDIT_VERBOSE=true`.
+Production HTTP, lifecycle, configuration, and audit events are emitted as JSON lines through `src/services/logger.service.js`. Each request receives a validated or generated correlation ID, returned in `X-Request-ID` and copied into related access and audit events as `id`. Auth and inventory mutations use `src/services/audit.service.js` (`login.success`, `login.failure`, `logout`, `firearm.create`, `firearm.update`, `firearm.delete`, `firearm.import`, etc.). By default, username and serial fields are redacted unless `AUDIT_VERBOSE=true`.

--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const { randomBytes } = require('crypto');
+const { randomBytes, randomUUID } = require('crypto');
 const express = require('express');
 const session = require('express-session');
 const methodOverride = require('method-override');
@@ -29,6 +29,55 @@ const { createReportsRepository } = require('../infra/db/repositories/reports.re
 const { createReportsService } = require('../features/reports/reports.service');
 const { createReportsController } = require('../features/reports/reports.controller');
 const { createReportsRoutes } = require('../features/reports/reports.routes');
+const logger = require('../services/logger.service');
+
+const REQUEST_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+function resolveRequestId(headerValue) {
+  if (typeof headerValue === 'string' && REQUEST_ID_PATTERN.test(headerValue)) {
+    return headerValue;
+  }
+  return randomUUID();
+}
+
+function numericToken(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function formatAccessLog(tokens, req, res) {
+  return JSON.stringify({
+    ts: new Date().toISOString(),
+    level: 'info',
+    event: 'http.request',
+    id: req.id,
+    method: tokens.method(req, res),
+    url: tokens.url(req, res),
+    status: numericToken(tokens.status(req, res)),
+    durationMs: numericToken(tokens['response-time'](req, res)),
+    contentLength: numericToken(tokens.res(req, res, 'content-length')),
+    remoteAddress: tokens['remote-addr'](req, res),
+    userAgent: tokens['user-agent'](req, res)
+  });
+}
+
+function createSessionStore(config, configuredStore) {
+  if (configuredStore) return configuredStore;
+
+  const memoryStore = new session.MemoryStore();
+  if (!config.isProduction) return memoryStore;
+
+  // express-session prints a multiline warning for its default store. Keep the
+  // warning, but expose it through the application's one-record-per-line logger.
+  const store = new session.Store();
+  for (const method of ['all', 'clear', 'destroy', 'get', 'set', 'length', 'touch']) {
+    store[method] = memoryStore[method].bind(memoryStore);
+  }
+  logger.warn('session.memory_store', {
+    message: 'The in-memory session store does not scale past one process and loses sessions on restart.'
+  });
+  return store;
+}
 
 async function createApp(options = {}) {
   const config = options.config || getConfig();
@@ -83,6 +132,12 @@ async function createApp(options = {}) {
     app.set('trust proxy', true);
   }
 
+  app.use((req, res, next) => {
+    req.id = resolveRequestId(req.get('x-request-id'));
+    res.setHeader('X-Request-ID', req.id);
+    next();
+  });
+
   app.use(
     helmet({
       hsts: {
@@ -93,7 +148,7 @@ async function createApp(options = {}) {
     })
   );
 
-  // Liveness probe: mounted before session, CSRF, and morgan so it stays cheap
+  // Liveness probe: mounted before session, CSRF, and access logging so it stays cheap
   // and never returns a 302 to /login. See README "Operations" section.
   app.get('/health', (req, res) => {
     res.json({ status: 'ok', version, uptime: process.uptime() });
@@ -104,10 +159,12 @@ async function createApp(options = {}) {
   app.use(express.urlencoded({ extended: true, limit: '50kb', parameterLimit: 100 }));
   app.use(methodOverride('_method'));
   if (config.isProduction) {
+    const accessLogOptions = {
+      skip: (req) => req.url.startsWith('/health'),
+      ...(options.accessLogStream ? { stream: options.accessLogStream } : {})
+    };
     app.use(
-      morgan('combined', {
-        skip: (req) => req.url.startsWith('/health')
-      })
+      morgan(formatAccessLog, accessLogOptions)
     );
   } else {
     app.use(morgan('dev', { skip: (req) => req.url.startsWith('/health') }));
@@ -115,6 +172,7 @@ async function createApp(options = {}) {
   app.use(
     session({
       secret: config.sessionSecret,
+      store: createSessionStore(config, options.sessionStore),
       resave: false,
       saveUninitialized: false,
       cookie: {
@@ -162,14 +220,22 @@ async function createApp(options = {}) {
   let csrfMisconfigLogged = false;
   app.use((err, req, res, next) => {
     if (err && err.code === 'EBADCSRFTOKEN') {
+      logger.warn('csrf.rejected', {
+        id: req.id,
+        method: req.method,
+        url: req.originalUrl,
+        proxyMisconfiguration: proxyMisconfig
+      });
       if (proxyMisconfig && !csrfMisconfigLogged) {
         csrfMisconfigLogged = true;
-        console.error(
-          '[csrf] Rejected a request because the CSRF cookie was missing. ' +
+        logger.error('csrf.proxy_misconfiguration', {
+          id: req.id,
+          message:
+            'Rejected a request because the CSRF cookie was missing. ' +
             'Secure cookies are enabled but TRUST_PROXY is not set, so the cookie is never delivered ' +
             'over a reverse-proxied HTTPS connection. ' +
             'Set TRUST_PROXY=true on the container, or set SECURE_COOKIES=false for plain-HTTP deployments.'
-        );
+        });
       }
       // The locals middleware runs after CSRF, so on rejection we populate
       // the layout's required values manually before rendering.
@@ -217,6 +283,24 @@ async function createApp(options = {}) {
     homeRoutes: createHomeRoutes(homeController),
     firearmsRoutes: createFirearmsRoutes(firearmsController),
     reportsRoutes: createReportsRoutes(reportsController)
+  });
+
+  app.use((err, req, res, next) => {
+    if (!config.isProduction) {
+      return next(err);
+    }
+
+    logger.error('http.request.failed', {
+      id: req.id,
+      method: req.method,
+      url: req.originalUrl,
+      message: err.message
+    });
+
+    if (res.headersSent) {
+      return next(err);
+    }
+    return res.status(500).send('Internal Server Error');
   });
 
   app.use((req, res) => {

--- a/src/features/auth/auth.controller.js
+++ b/src/features/auth/auth.controller.js
@@ -30,13 +30,13 @@ function createAuthController(authService) {
       const valid = await authService.validateCredentials(username, password);
 
       if (!valid) {
-        auditLog('login.failure', { ip: req.ip, username });
+        auditLog('login.failure', { id: req.id, ip: req.ip, username });
         return res.status(401).render('auth/login', { pageTitle: 'Login', error: 'Invalid credentials' });
       }
 
       req.session.user = { username, id: 1 };
       req.session.mustChangePassword = authService.mustChangePassword();
-      auditLog('login.success', { ip: req.ip, username });
+      auditLog('login.success', { id: req.id, ip: req.ip, username });
 
       if (req.session.mustChangePassword) {
         return res.redirect('/change-password');
@@ -48,7 +48,7 @@ function createAuthController(authService) {
     logout(req, res) {
       const username = req.session?.user?.username;
       req.session.destroy(() => {
-        auditLog('logout', { ip: req.ip, username });
+        auditLog('logout', { id: req.id, ip: req.ip, username });
         res.redirect('/login');
       });
     },
@@ -71,7 +71,7 @@ function createAuthController(authService) {
       }
 
       req.session.mustChangePassword = false;
-      auditLog('password.change', { ip: req.ip, username: req.session?.user?.username });
+      auditLog('password.change', { id: req.id, ip: req.ip, username: req.session?.user?.username });
       return res.redirect('/');
     },
 
@@ -89,7 +89,7 @@ function createAuthController(authService) {
       const previous = req.session?.user?.username;
       req.session.user = { ...req.session.user, username: result.username };
       res.locals.user = req.session.user;
-      auditLog('username.change', { ip: req.ip, previous, username: result.username });
+      auditLog('username.change', { id: req.id, ip: req.ip, previous, username: result.username });
 
       return res.render(
         'auth/profile',
@@ -114,7 +114,7 @@ function createAuthController(authService) {
       }
 
       req.session.mustChangePassword = false;
-      auditLog('password.change', { ip: req.ip, username: req.session?.user?.username });
+      auditLog('password.change', { id: req.id, ip: req.ip, username: req.session?.user?.username });
       return res.render('auth/profile', createProfileViewModel({ passwordSuccess: 'Password updated successfully.' }));
     },
 

--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -70,7 +70,7 @@ function createFirearmsController(firearmsService) {
       try {
         const id = firearmsService.create(data, userId);
         if (req.session) req.session.flash = { type: 'success', message: 'Firearm added.' };
-        auditLog('firearm.create', { ip: req.ip, id });
+        auditLog('firearm.create', { id: req.id, ip: req.ip, firearmId: id });
         return res.redirect(`/firearms/${id}`);
       } catch (err) {
         if (err.code === 'DUPLICATE_SERIAL') {
@@ -136,7 +136,7 @@ function createFirearmsController(firearmsService) {
       try {
         firearmsService.update(req.params.id, data, userId);
         if (req.session) req.session.flash = { type: 'success', message: 'Firearm updated.' };
-        auditLog('firearm.update', { ip: req.ip, id: req.params.id });
+        auditLog('firearm.update', { id: req.id, ip: req.ip, firearmId: req.params.id });
         return res.redirect(`/firearms/${req.params.id}`);
       } catch (err) {
         if (err.code === 'DUPLICATE_SERIAL') {
@@ -159,7 +159,7 @@ function createFirearmsController(firearmsService) {
       }
       firearmsService.remove(req.params.id, userId);
       if (req.session) req.session.flash = { type: 'success', message: 'Firearm deleted.' };
-      auditLog('firearm.delete', { ip: req.ip, id: req.params.id });
+      auditLog('firearm.delete', { id: req.id, ip: req.ip, firearmId: req.params.id });
       return res.redirect('/firearms');
     },
 
@@ -186,6 +186,7 @@ function createFirearmsController(firearmsService) {
         });
       }
       auditLog('firearm.import', {
+        id: req.id,
         ip: req.ip,
         imported: results.imported,
         failed: results.failed

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const logger = require('../../services/logger.service');
 
 const DEFAULT_ADMIN_PASSWORD = 'changeme';
 const DEFAULT_SESSION_SECRET = 'ppcollection_dev_secret';
@@ -17,20 +18,22 @@ function getConfig() {
   const sessionSecret = process.env.SESSION_SECRET || DEFAULT_SESSION_SECRET;
 
   if (secureCookies && !trustProxy) {
-    console.warn(
-      '[config] WARNING: secure cookies are enabled but TRUST_PROXY is not. ' +
+    logger.warn('config.secure_cookies_without_trust_proxy', {
+      message:
+        'Secure cookies are enabled but TRUST_PROXY is not. ' +
         'When the app sits behind an HTTPS reverse proxy, Express needs to recognize the request ' +
         'as HTTPS for the cookie to be sent. Sessions may silently fail to persist. ' +
         'Set TRUST_PROXY=true, or set SECURE_COOKIES=false to disable secure cookies for this deployment.'
-    );
+    });
   }
 
   if (adminPass === DEFAULT_ADMIN_PASSWORD) {
-    console.warn(
-      '[config] WARNING: ADMIN_PASSWORD is unset or using the documented default. ' +
+    logger.warn('config.default_admin_password', {
+      message:
+        'ADMIN_PASSWORD is unset or using the documented default. ' +
         'Set ADMIN_PASSWORD to a strong value before exposing the app. ' +
         'In production, the app will refuse to seed an admin account with this value.'
-    );
+    });
   }
 
   if (sessionSecret === DEFAULT_SESSION_SECRET) {
@@ -40,10 +43,11 @@ function getConfig() {
           'Set SESSION_SECRET to a random value (e.g. `openssl rand -base64 48`) before starting in production.'
       );
     }
-    console.warn(
-      '[config] WARNING: SESSION_SECRET is unset or using the insecure default. ' +
+    logger.warn('config.default_session_secret', {
+      message:
+        'SESSION_SECRET is unset or using the insecure default. ' +
         'Set SESSION_SECRET to a strong random value before exposing the app.'
-    );
+    });
   }
 
   const databasePath = resolveDatabasePath(process.env.DATABASE_PATH, process.env.DATA_DIR);

--- a/src/server.js
+++ b/src/server.js
@@ -1,17 +1,18 @@
 const { createApp } = require('./app/createApp');
 const { getConfig } = require('./infra/config');
+const logger = require('./services/logger.service');
 
 const SHUTDOWN_TIMEOUT_MS = 10_000;
 
-const config = getConfig();
-
-createApp({ config }).then((app) => {
+async function start() {
+  const config = getConfig();
+  const app = await createApp({ config });
   const server = app.listen(config.port, () => {
-    console.log(`PPCollection listening on http://localhost:${config.port}`);
+    logger.info('server.started', { port: config.port, url: `http://localhost:${config.port}` });
   });
 
   function shutdown(signal) {
-    console.log(`[shutdown] received ${signal}, draining connections…`);
+    logger.info('server.shutdown.started', { signal });
     server.close(() => {
       try {
         app.locals.db?.close();
@@ -21,11 +22,16 @@ createApp({ config }).then((app) => {
       process.exit(0);
     });
     setTimeout(() => {
-      console.error('[shutdown] timed out waiting for connections, forcing exit');
+      logger.error('server.shutdown.timeout', { signal, timeoutMs: SHUTDOWN_TIMEOUT_MS });
       process.exit(1);
     }, SHUTDOWN_TIMEOUT_MS).unref();
   }
 
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
+}
+
+start().catch((err) => {
+  logger.error('server.start.failed', { message: err.message });
+  process.exit(1);
 });

--- a/src/services/audit.service.js
+++ b/src/services/audit.service.js
@@ -1,3 +1,5 @@
+const logger = require('./logger.service');
+
 // Lightweight structured audit log to stdout. Picked up by Docker / journald
 // log collectors without adding a new sink. Sensitive fields are gated behind
 // AUDIT_VERBOSE so the default log stream stays free of PII.
@@ -5,14 +7,14 @@ function auditLog(event, meta = {}) {
   if (process.env.NODE_ENV === 'test') return;
 
   const verbose = process.env.AUDIT_VERBOSE === 'true';
-  const entry = { ts: new Date().toISOString(), event, ...meta };
+  const entry = { ...meta };
 
   if (!verbose) {
     delete entry.username;
     delete entry.serial;
   }
 
-  console.log(JSON.stringify(entry));
+  logger.info(event, entry);
 }
 
 module.exports = { auditLog };

--- a/src/services/logger.service.js
+++ b/src/services/logger.service.js
@@ -1,0 +1,33 @@
+function writeLog(level, event, meta = {}) {
+  const entry = {
+    ...meta,
+    ts: new Date().toISOString(),
+    level,
+    event
+  };
+  const serialized = JSON.stringify(entry);
+
+  if (level === 'error') {
+    console.error(serialized);
+  } else if (level === 'warn') {
+    console.warn(serialized);
+  } else {
+    console.log(serialized);
+  }
+
+  return entry;
+}
+
+function info(event, meta) {
+  return writeLog('info', event, meta);
+}
+
+function warn(event, meta) {
+  return writeLog('warn', event, meta);
+}
+
+function error(event, meta) {
+  return writeLog('error', event, meta);
+}
+
+module.exports = { info, warn, error };

--- a/tests/integration/logging.integration.test.js
+++ b/tests/integration/logging.integration.test.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('supertest');
+
+const { createApp } = require('../../src/app/createApp');
+
+describe('structured request logging', () => {
+  let app;
+  let dbPath;
+  let tempDir;
+  let originalNodeEnv;
+  let accessLogStream;
+
+  beforeEach(async () => {
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-logging-'));
+    dbPath = path.join(tempDir, 'test.db');
+    accessLogStream = { write: jest.fn() };
+    app = await createApp({
+      config: {
+        port: 0,
+        sessionSecret: 'structured-logging-test-secret',
+        adminUser: 'admin',
+        adminPass: 'password123',
+        databasePath: dbPath,
+        trustProxy: false,
+        secureCookies: false,
+        isProduction: true,
+        updateCheck: false
+      },
+      accessLogStream
+    });
+  });
+
+  afterEach(() => {
+    app.locals.db.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  test('generates a request ID and exposes it on the health response', async () => {
+    const response = await request(app).get('/health').expect(200);
+
+    expect(response.headers['x-request-id']).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+    expect(accessLogStream.write).not.toHaveBeenCalled();
+  });
+
+  test('preserves a valid caller-provided request ID end to end', async () => {
+    const response = await request(app)
+      .get('/login')
+      .set('X-Request-ID', 'caller-request_123:abc')
+      .expect(200);
+
+    expect(response.headers['x-request-id']).toBe('caller-request_123:abc');
+    const entry = JSON.parse(accessLogStream.write.mock.calls[0][0]);
+    expect(entry).toMatchObject({
+      level: 'info',
+      event: 'http.request',
+      id: 'caller-request_123:abc',
+      method: 'GET',
+      url: '/login',
+      status: 200
+    });
+    expect(entry.durationMs).toEqual(expect.any(Number));
+  });
+
+  test('replaces an invalid caller-provided request ID', async () => {
+    const response = await request(app)
+      .get('/login')
+      .set('X-Request-ID', 'invalid request id')
+      .expect(200);
+
+    expect(response.headers['x-request-id']).not.toBe('invalid request id');
+    expect(response.headers['x-request-id']).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});

--- a/tests/unit/audit.service.test.js
+++ b/tests/unit/audit.service.test.js
@@ -27,13 +27,15 @@ describe('auditLog', () => {
 
   test('emits structured JSON with timestamp and event', () => {
     process.env.NODE_ENV = 'production';
-    auditLog('firearm.create', { ip: '10.0.0.1', id: 7 });
+    auditLog('firearm.create', { id: 'request-123', ip: '10.0.0.1', firearmId: 7 });
     expect(logSpy).toHaveBeenCalledTimes(1);
 
     const entry = JSON.parse(logSpy.mock.calls[0][0]);
     expect(entry.event).toBe('firearm.create');
+    expect(entry.level).toBe('info');
+    expect(entry.id).toBe('request-123');
     expect(entry.ip).toBe('10.0.0.1');
-    expect(entry.id).toBe(7);
+    expect(entry.firearmId).toBe(7);
     expect(entry.ts).toMatch(/\d{4}-\d{2}-\d{2}T/);
   });
 

--- a/tests/unit/logger.service.test.js
+++ b/tests/unit/logger.service.test.js
@@ -1,0 +1,47 @@
+const logger = require('../../src/services/logger.service');
+
+describe('logger service', () => {
+  let logSpy;
+  let warnSpy;
+  let errorSpy;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  test('emits one structured JSON line for informational events', () => {
+    logger.info('server.started', { port: 3000 });
+
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const entry = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(entry).toMatchObject({ level: 'info', event: 'server.started', port: 3000 });
+    expect(entry.ts).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test('uses the matching console stream for warning and error events', () => {
+    logger.warn('config.warning', { message: 'check configuration' });
+    logger.error('server.failed', { message: 'startup failed' });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(warnSpy.mock.calls[0][0]).level).toBe('warn');
+    expect(JSON.parse(errorSpy.mock.calls[0][0]).level).toBe('error');
+  });
+
+  test('does not allow metadata to replace core log fields', () => {
+    logger.info('expected.event', { event: 'spoofed.event', level: 'error', ts: 'invalid' });
+
+    expect(JSON.parse(logSpy.mock.calls[0][0])).toMatchObject({
+      event: 'expected.event',
+      level: 'info'
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- emit production access, lifecycle, configuration, CSRF, failure, and audit logs as one JSON object per line
- assign each request a validated or generated correlation `id`, return it in `X-Request-ID`, and propagate it to related audit events
- document the log schema and preserve the in-memory session-store warning as structured JSON
- add unit and integration coverage for logger behavior and request-ID handling

## Validation

- `npm run lint`
- `npm run test:ci` (20 suites, 183 tests)
- `npm audit --audit-level=high --omit=dev` (0 vulnerabilities)
- production-mode smoke test parsing every stdout/stderr line as JSON and verifying caller-provided IDs end to end

Closes #419