### PR TITLE
feat: maintenance logs, range sessions, and photo attachments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,22 +62,25 @@ src/
 ├── features/
 │   ├── auth/                 # Login, change-password, profile, theme toggle
 │   ├── firearms/             # Inventory CRUD, CSV import/export
-│   └── home/                 # Dashboard
+│   ├── home/                 # Dashboard
+│   ├── maintenance/          # Per-firearm maintenance log + cleaning-due rule
+│   ├── photos/               # Per-firearm photo attachments (multer, <dataDir>/photos)
+│   └── range-sessions/       # Per-firearm range session log
 │       └── (each contains <feature>.controller.js,
 │                            <feature>.routes.js,
 │                            <feature>.service.js,
 │                            <feature>.validators.js [if needed])
 ├── infra/
-│   ├── config/index.js       # Reads + validates env vars; exports getConfig()
+│   ├── config/index.js       # Reads + validates env vars; exports getConfig() (incl. dataDir/photosDir)
 │   └── db/
 │       ├── client.js         # better-sqlite3 connection
 │       ├── migrate.js        # Numbered SQL migration runner (schema_migrations table)
-│       ├── migrations/       # 001_initial_schema.sql, 002_settings_table.sql, 003_disposition_fields.sql
-│       └── repositories/     # firearms.repository.js, settings.repository.js
+│       ├── migrations/       # 001_initial_schema.sql … 007_firearm_photos.sql
+│       └── repositories/     # firearms, settings, maintenance, range-sessions, photos
 ├── services/
 │   └── version.service.js    # Opt-in GitHub Releases lookup (UPDATE_CHECK)
 ├── shared/
-│   └── utils/csv.js          # CSV parse + serialise
+│   └── utils/                # csv.js (CSV parse + serialise), dates.js (strict ISO date check)
 ├── public/
 │   ├── css/styles.css        # Single stylesheet, dark + light via [data-theme]
 │   └── js/                   # search.js, theme.js, firearm-form.js, etc.
@@ -100,11 +103,12 @@ src/
 ## Database
 
 - SQLite is the correct and intentional database choice — do not suggest replacing it
-- Schema changes are new numbered SQL migration files in `src/infra/db/migrations/` (e.g. `004_*.sql`)
+- Schema changes are new numbered SQL migration files in `src/infra/db/migrations/` (e.g. `008_*.sql`)
 - The migration runner records applied files in a `schema_migrations` table; never modify or rename a migration that has already shipped
-- `maintenance_logs` and `range_sessions` tables exist in `001_initial_schema.sql` but have no UI yet — intentional, reserved for future features
+- `maintenance_logs` and `range_sessions` (in `001_initial_schema.sql`) back the maintenance log and range session sections on the firearm detail page; neither has a `user_id` column — ownership is checked through the parent firearm
+- `firearm_photos` (added in `007_*.sql`) stores photo metadata; image files live under `<dataDir>/photos` with server-generated filenames and are served only via an authenticated, ownership-checked route
 - Disposition fields (`disposition_name`, `disposition_address`, `disposition_date`, `disposition_reason`) were added in `003_*.sql` and are written/cleared based on `status` in `firearms.validators.js`
-- The `settings` table is a key/value store used by `settings.repository.js` for: `username`, `password_hash`, `must_change_password`, `theme`, `update_check_enabled`
+- The `settings` table is a key/value store used by `settings.repository.js` for: `username`, `password_hash`, `must_change_password`, `theme`, `update_check_enabled`, `maintenance_due_days` (cleaning reminder threshold, 1–365 days, default 90)
 
 ---
 
@@ -115,7 +119,7 @@ These were on the old backlog and are now implemented — do **not** suggest re-
 - **Bcrypt password hashing** — `auth.service.js` uses `bcrypt.compare` / `bcrypt.hash` at cost 12. The plain `ADMIN_PASSWORD` env var is only used to seed the hash on first run.
 - **First-run admin guard** — In production the app refuses to start if `ADMIN_PASSWORD` is unset or `changeme` and no hash exists yet.
 - **Forced password change on first login** — `must_change_password` flag in settings; `requireAuth` redirects to `/change-password` until cleared.
-- **CSRF protection** — `csrf-csrf` double-submit cookie. Token surfaced as `res.locals.csrfToken`; rejected requests render `errors/403.ejs`.
+- **CSRF protection** — `csrf-csrf` double-submit cookie. Token surfaced as `res.locals.csrfToken`; rejected requests render `errors/403.ejs`. Multipart uploads (photos) must send the token via the `x-csrf-token` header — the body is parsed by multer *after* the CSRF check, so a `_csrf` form field is invisible to it.
 - **Rate limiting** — login (failed only) and password-change endpoints (see `auth.routes.js`).
 - **Helmet defaults** — CSP is enabled (the old `contentSecurityPolicy: false` is gone).
 - **Secure cookies** — Default `true` when `NODE_ENV=production`. `TRUST_PROXY=true` is required behind an HTTPS reverse proxy or sessions silently fail; the config layer warns on the misconfig.
@@ -139,11 +143,13 @@ These were on the old backlog and are now implemented — do **not** suggest re-
 - Codex planning document exists covering: container padding, table overflow, form grid, tap targets, action bar stacking. Inventory rows already collapse to cards on mobile per the README.
 
 ### Features Planned
-- Maintenance log UI (schema already exists)
-- Range session tracking UI (schema already exists)
 - Reporting & analytics dashboard (beyond current home charts)
-- Photo attachments (stored locally in Docker volume)
 - gun-db auto-fill — pre-populate make/model from the related `gun-db` dataset
+
+### Recently Shipped (do not re-propose as new work)
+- Maintenance log UI with configurable cleaning-due reminder (#149)
+- Range session tracking UI with per-firearm totals (#151)
+- Photo attachments stored locally under `<dataDir>/photos` (#152)
 
 ---
 
@@ -156,6 +162,7 @@ These were on the old backlog and are now implemented — do **not** suggest re-
 | `ADMIN_USERNAME` | Admin login username | `admin` |
 | `ADMIN_PASSWORD` | Initial admin password (hashed on first run). **Required for first-run in production.** | `changeme` |
 | `DATABASE_PATH` | SQLite file location | `<cwd>/data/app.db` (Docker: `/data/app.db`) |
+| `DATA_DIR` | Base data directory; also derives the photo storage dir (`<DATA_DIR>/photos`) | `<cwd>/data` (Docker: `/data`) |
 | `NODE_ENV` | `production` triggers stricter guards and secure-cookie defaults | unset |
 | `TRUST_PROXY` | Honor `X-Forwarded-Proto` from a reverse proxy | `false` |
 | `SECURE_COOKIES` | Force `Secure` flag on cookies | `true` when `NODE_ENV=production`, else `false` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ src/
 │   └── db/
 │       ├── client.js         # better-sqlite3 connection
 │       ├── migrate.js        # Numbered SQL migration runner (schema_migrations table)
-│       ├── migrations/       # 001_initial_schema.sql … 007_firearm_photos.sql
+│       ├── migrations/       # 001_initial_schema.sql … 008_log_indexes.sql
 │       └── repositories/     # firearms, settings, maintenance, range-sessions, photos
 ├── services/
 │   └── version.service.js    # Opt-in GitHub Releases lookup (UPDATE_CHECK)
@@ -103,7 +103,7 @@ src/
 ## Database
 
 - SQLite is the correct and intentional database choice — do not suggest replacing it
-- Schema changes are new numbered SQL migration files in `src/infra/db/migrations/` (e.g. `008_*.sql`)
+- Schema changes are new numbered SQL migration files in `src/infra/db/migrations/` (e.g. `009_*.sql`)
 - The migration runner records applied files in a `schema_migrations` table; never modify or rename a migration that has already shipped
 - `maintenance_logs` and `range_sessions` (in `001_initial_schema.sql`) back the maintenance log and range session sections on the firearm detail page; neither has a `user_id` column — ownership is checked through the parent firearm
 - `firearm_photos` (added in `007_*.sql`) stores photo metadata; image files live under `<dataDir>/photos` with server-generated filenames and are served only via an authenticated, ownership-checked route

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ build step, one Docker command to run.
   login, CSRF on every form
 - **Fully offline** — zero internet at runtime; the GitHub Releases update
   check is opt-in
-- **One SQLite file** — back up your whole collection with `cp`
+- **One data directory** — the SQLite database and photo files live together
+  under `/data`; back up that one directory with `cp`
 - **Docker ready** — multi-arch image on GHCR
 
 ## Quick start

--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ build step, one Docker command to run.
   details, warranty, and notes
 - **Disposition tracking** — records sold/lost/stolen items with transferee,
   date, and reason; included in CSV exports
+- **Maintenance log** — per-firearm cleaning, repair, and part-replacement
+  entries, with a configurable due-for-cleaning reminder
+- **Range sessions** — per-firearm session log with date, location, rounds
+  fired, and running totals
+- **Photo attachments** — up to 12 photos per firearm, stored locally in the
+  data volume (`/data/photos`)
 - **Dashboard and stats** — recent activity, type/caliber/make breakdowns,
-  acquisition trends, average price by year
+  acquisition trends, average price by year, cleaning-due list
 - **Insurance report** — print-friendly inventory with total purchase value
 - **Search, filter, sort** — real-time across all fields; mobile rows collapse
   to cards
@@ -42,8 +48,9 @@ docker run -d \
 ```
 
 Open <http://localhost:3000> and log in. You will be prompted to change the
-password on first login. Your data lives in `./data/app.db` on the host —
-back up that directory to back up your collection.
+password on first login. Your data lives in `./data` on the host — the SQLite
+database at `./data/app.db` and any firearm photos under `./data/photos` —
+so backing up that one directory backs up your whole collection.
 
 > Use an absolute host path for the volume (or a named volume like
 > `-v ppcollection_data:/data`). Docker treats a bare `./data` as an

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,8 @@ src/
 │       │   ├── 004_user_id.sql           # user_id column on firearms (single-user scoping)
 │       │   ├── 005_indexes.sql           # Performance indexes on status, condition, type, make+model
 │       │   ├── 006_serial_unique.sql     # Scoped unique index on user_id + serial
-│       │   └── 007_firearm_photos.sql    # firearm_photos table (photo metadata; files on disk)
+│       │   ├── 007_firearm_photos.sql    # firearm_photos table (photo metadata; files on disk)
+│       │   └── 008_log_indexes.sql       # Indexes for maintenance_logs and range_sessions lookups
 │       └── repositories/
 │           ├── firearms.repository.js  # SQL for inventory CRUD, pagination, charts (scoped by user_id)
 │           ├── maintenance.repository.js # SQL for maintenance logs + cleaning-status aggregates

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,7 +26,21 @@ src/
 │   ├── home/
 │   │   ├── home.controller.js    # Dashboard view
 │   │   ├── home.routes.js        # / (dashboard)
-│   │   └── home.service.js       # Collection stats, activity feed, chart data
+│   │   └── home.service.js       # Collection stats, activity feed, chart data, cleaning-due list
+│   ├── maintenance/
+│   │   ├── maintenance.controller.js # Add/delete maintenance log entries
+│   │   ├── maintenance.routes.js     # /firearms/:firearmId/maintenance[…]
+│   │   ├── maintenance.service.js    # CRUD + cleaning-due rule (threshold from settings)
+│   │   └── maintenance.validators.js # Date/type/notes/round-delta validation
+│   ├── photos/
+│   │   ├── photos.controller.js  # Upload (AJAX), serve, delete firearm photos
+│   │   ├── photos.routes.js      # /firearms/:firearmId/photos[…] (multer memory storage)
+│   │   └── photos.service.js     # Disk storage under <dataDir>/photos, caps and cleanup
+│   ├── range-sessions/
+│   │   ├── range-sessions.controller.js # Add/delete range sessions
+│   │   ├── range-sessions.routes.js     # /firearms/:firearmId/range-sessions[…]
+│   │   ├── range-sessions.service.js    # CRUD + per-firearm totals
+│   │   └── range-sessions.validators.js # Date/location/rounds/notes validation
 │   └── reports/
 │       ├── reports.controller.js  # Analytics dashboard view
 │       ├── reports.routes.js      # /reports
@@ -43,9 +57,13 @@ src/
 │       │   ├── 003_disposition_fields.sql # disposition_name/address/date/reason columns
 │       │   ├── 004_user_id.sql           # user_id column on firearms (single-user scoping)
 │       │   ├── 005_indexes.sql           # Performance indexes on status, condition, type, make+model
-│       │   └── 006_serial_unique.sql     # Scoped unique index on user_id + serial
+│       │   ├── 006_serial_unique.sql     # Scoped unique index on user_id + serial
+│       │   └── 007_firearm_photos.sql    # firearm_photos table (photo metadata; files on disk)
 │       └── repositories/
 │           ├── firearms.repository.js  # SQL for inventory CRUD, pagination, charts (scoped by user_id)
+│           ├── maintenance.repository.js # SQL for maintenance logs + cleaning-status aggregates
+│           ├── photos.repository.js    # SQL for firearm photo metadata
+│           ├── range-sessions.repository.js # SQL for range sessions + per-firearm totals
 │           ├── reports.repository.js   # SQL for analytics: summaries, breakdowns, trends
 │           └── settings.repository.js  # SQL for key/value settings
 ├── services/
@@ -126,10 +144,17 @@ src/
 | `must_change_password` | `1` if forced change required on next login |
 | `theme` | `dark` or `light` — persisted server-side |
 | `update_check_enabled` | `1` if the user has opted in to update notifications (only settable when `UPDATE_CHECK=true` at the server level) |
+| `maintenance_due_days` | Days after the last cleaning before a firearm is flagged as due (1–365, default 90; editable on the profile page) |
 
-### Reserved tables (no UI yet)
+### Per-firearm child tables
 
-`maintenance_logs` and `range_sessions` are created in `001_initial_schema.sql` with foreign keys to `firearms.id`. They are reserved for a future maintenance and range-session tracking feature.
+`maintenance_logs` and `range_sessions` are created in `001_initial_schema.sql` with `ON DELETE CASCADE` foreign keys to `firearms.id` and back the maintenance log and range session sections on the firearm detail page. Neither table has a `user_id` column — ownership is always checked through the parent firearm.
+
+A firearm is flagged **due for cleaning** when its most recent `Cleaning` maintenance entry is older than the `maintenance_due_days` threshold, or when a range session is newer than the last cleaning (including fired-but-never-cleaned). Disposed firearms are never flagged.
+
+### Photo attachments
+
+`firearm_photos` (added in `007_firearm_photos.sql`) stores photo metadata; the image files live on disk under `<dataDir>/photos` (Docker: `/data/photos`) with server-generated random filenames. Uploads go through `multer` (memory storage, 10 MB cap, JPEG/PNG/WebP/GIF only, max 12 photos per firearm) and must send the CSRF token in the `x-csrf-token` header because multipart bodies are parsed after the CSRF check. Photos are served only through an authenticated, ownership-checked route — the photos directory is never mounted as static. Deleting a photo or its firearm also unlinks the files on disk.
 
 ## CSRF protection
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1130,7 +1130,7 @@
       </details>
       <details class="faq-item">
         <summary>What about photos, receipts, or appraisals?</summary>
-        <p>Photo attachments are on the roadmap. For now, store photos alongside your <code>app.db</code> backup and reference the filenames in the Notes field.</p>
+        <p>Photo attachments are built in: upload up to 12 photos per firearm from its detail page. Images are stored locally in your data volume (<code>/data/photos</code>), so backing up the data directory captures the database and photos together.</p>
       </details>
     </div>
   </section>
@@ -1147,7 +1147,7 @@
       { "@type": "Question", "name": "Does this work without internet?", "acceptedAnswer": { "@type": "Answer", "text": "Yes. After the initial Docker pull, the app runs entirely offline. There is one opt-in feature (UPDATE_CHECK=true) that checks GitHub for new releases; it is off by default." } },
       { "@type": "Question", "name": "Is it really free? What's the catch?", "acceptedAnswer": { "@type": "Answer", "text": "Yes, licensed under the Business Source License 1.1; personal, non-commercial, self-hosted use is free with no catch. A future paid tier may add premium features, but everything currently shipped stays free. The license converts to Apache 2.0 on 2029-05-13." } },
       { "@type": "Question", "name": "How do I import my existing spreadsheet?", "acceptedAnswer": { "@type": "Answer", "text": "CSV import is built in. Match your columns to the field names listed in the import dialog and import in one click." } },
-      { "@type": "Question", "name": "What about photos, receipts, or appraisals?", "acceptedAnswer": { "@type": "Answer", "text": "Photo attachments are on the roadmap. For now, store photos alongside your app.db backup and reference the filenames in the Notes field." } }
+      { "@type": "Question", "name": "What about photos, receipts, or appraisals?", "acceptedAnswer": { "@type": "Answer", "text": "Photo attachments are built in: upload up to 12 photos per firearm from its detail page. Images are stored locally in your data volume (/data/photos), so backing up the data directory captures the database and photos together." } }
     ]
   }
   </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "express-session": "^1.19.0",
         "helmet": "^8.3.0",
         "method-override": "^3.0.0",
-        "morgan": "^1.11.0"
+        "morgan": "^1.11.0",
+        "multer": "^2.2.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -2725,6 +2726,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3125,8 +3132,18 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3616,6 +3633,35 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/config-chain": {
       "version": "1.1.13",
@@ -7157,6 +7203,68 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/multer/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/multer/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -11241,6 +11349,14 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -11937,6 +12053,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "express-session": "^1.19.0",
     "helmet": "^8.3.0",
     "method-override": "^3.0.0",
-    "morgan": "^1.11.0"
+    "morgan": "^1.11.0",
+    "multer": "^2.2.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",

--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -29,6 +29,10 @@ const { createMaintenanceRepository } = require('../infra/db/repositories/mainte
 const { createMaintenanceService } = require('../features/maintenance/maintenance.service');
 const { createMaintenanceController } = require('../features/maintenance/maintenance.controller');
 const { createMaintenanceRoutes } = require('../features/maintenance/maintenance.routes');
+const { createRangeSessionsRepository } = require('../infra/db/repositories/range-sessions.repository');
+const { createRangeSessionsService } = require('../features/range-sessions/range-sessions.service');
+const { createRangeSessionsController } = require('../features/range-sessions/range-sessions.controller');
+const { createRangeSessionsRoutes } = require('../features/range-sessions/range-sessions.routes');
 const { createReportsRepository } = require('../infra/db/repositories/reports.repository');
 const { createReportsService } = require('../features/reports/reports.service');
 const { createReportsController } = require('../features/reports/reports.controller');
@@ -121,7 +125,10 @@ async function createApp(options = {}) {
   const maintenanceRepository = createMaintenanceRepository(db);
   const maintenanceService = createMaintenanceService(maintenanceRepository, settingsRepository);
   const maintenanceController = createMaintenanceController({ maintenanceService, firearmsService });
-  const firearmsController = createFirearmsController(firearmsService, { maintenanceService });
+  const rangeSessionsRepository = createRangeSessionsRepository(db);
+  const rangeSessionsService = createRangeSessionsService(rangeSessionsRepository);
+  const rangeSessionsController = createRangeSessionsController({ rangeSessionsService, firearmsService });
+  const firearmsController = createFirearmsController(firearmsService, { maintenanceService, rangeSessionsService });
   const homeService = createHomeService(firearmsRepository, maintenanceService);
   const homeController = createHomeController(homeService);
   const reportsRepository = createReportsRepository(db);
@@ -290,6 +297,7 @@ async function createApp(options = {}) {
     homeRoutes: createHomeRoutes(homeController),
     firearmsRoutes: createFirearmsRoutes(firearmsController),
     maintenanceRoutes: createMaintenanceRoutes(maintenanceController),
+    rangeSessionsRoutes: createRangeSessionsRoutes(rangeSessionsController),
     reportsRoutes: createReportsRoutes(reportsController)
   });
 

--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const { randomBytes, randomUUID } = require('crypto');
 const express = require('express');
@@ -33,6 +34,10 @@ const { createRangeSessionsRepository } = require('../infra/db/repositories/rang
 const { createRangeSessionsService } = require('../features/range-sessions/range-sessions.service');
 const { createRangeSessionsController } = require('../features/range-sessions/range-sessions.controller');
 const { createRangeSessionsRoutes } = require('../features/range-sessions/range-sessions.routes');
+const { createPhotosRepository } = require('../infra/db/repositories/photos.repository');
+const { createPhotosService } = require('../features/photos/photos.service');
+const { createPhotosController } = require('../features/photos/photos.controller');
+const { createPhotosRoutes } = require('../features/photos/photos.routes');
 const { createReportsRepository } = require('../infra/db/repositories/reports.repository');
 const { createReportsService } = require('../features/reports/reports.service');
 const { createReportsController } = require('../features/reports/reports.controller');
@@ -128,7 +133,17 @@ async function createApp(options = {}) {
   const rangeSessionsRepository = createRangeSessionsRepository(db);
   const rangeSessionsService = createRangeSessionsService(rangeSessionsRepository);
   const rangeSessionsController = createRangeSessionsController({ rangeSessionsService, firearmsService });
-  const firearmsController = createFirearmsController(firearmsService, { maintenanceService, rangeSessionsService });
+  // Photos live next to the database so a /data backup captures both.
+  const photosDir = config.photosDir || path.join(path.dirname(config.databasePath), 'photos');
+  fs.mkdirSync(photosDir, { recursive: true });
+  const photosRepository = createPhotosRepository(db);
+  const photosService = createPhotosService({ photosRepository, photosDir });
+  const photosController = createPhotosController({ photosService, firearmsService, photosDir });
+  const firearmsController = createFirearmsController(firearmsService, {
+    maintenanceService,
+    rangeSessionsService,
+    photosService
+  });
   const homeService = createHomeService(firearmsRepository, maintenanceService);
   const homeController = createHomeController(homeService);
   const reportsRepository = createReportsRepository(db);
@@ -298,6 +313,7 @@ async function createApp(options = {}) {
     firearmsRoutes: createFirearmsRoutes(firearmsController),
     maintenanceRoutes: createMaintenanceRoutes(maintenanceController),
     rangeSessionsRoutes: createRangeSessionsRoutes(rangeSessionsController),
+    photosRoutes: createPhotosRoutes(photosController),
     reportsRoutes: createReportsRoutes(reportsController)
   });
 

--- a/src/app/createApp.js
+++ b/src/app/createApp.js
@@ -25,6 +25,10 @@ const { createFirearmsRoutes } = require('../features/firearms/firearms.routes')
 const { createHomeService } = require('../features/home/home.service');
 const { createHomeController } = require('../features/home/home.controller');
 const { createHomeRoutes } = require('../features/home/home.routes');
+const { createMaintenanceRepository } = require('../infra/db/repositories/maintenance.repository');
+const { createMaintenanceService } = require('../features/maintenance/maintenance.service');
+const { createMaintenanceController } = require('../features/maintenance/maintenance.controller');
+const { createMaintenanceRoutes } = require('../features/maintenance/maintenance.routes');
 const { createReportsRepository } = require('../infra/db/repositories/reports.repository');
 const { createReportsService } = require('../features/reports/reports.service');
 const { createReportsController } = require('../features/reports/reports.controller');
@@ -114,8 +118,11 @@ async function createApp(options = {}) {
 
   const authController = createAuthController(authService);
   const firearmsService = createFirearmsService(firearmsRepository);
-  const firearmsController = createFirearmsController(firearmsService);
-  const homeService = createHomeService(firearmsRepository);
+  const maintenanceRepository = createMaintenanceRepository(db);
+  const maintenanceService = createMaintenanceService(maintenanceRepository, settingsRepository);
+  const maintenanceController = createMaintenanceController({ maintenanceService, firearmsService });
+  const firearmsController = createFirearmsController(firearmsService, { maintenanceService });
+  const homeService = createHomeService(firearmsRepository, maintenanceService);
   const homeController = createHomeController(homeService);
   const reportsRepository = createReportsRepository(db);
   const reportsService = createReportsService(reportsRepository);
@@ -282,6 +289,7 @@ async function createApp(options = {}) {
     authRoutes: createAuthRoutes(authController),
     homeRoutes: createHomeRoutes(homeController),
     firearmsRoutes: createFirearmsRoutes(firearmsController),
+    maintenanceRoutes: createMaintenanceRoutes(maintenanceController),
     reportsRoutes: createReportsRoutes(reportsController)
   });
 

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -1,9 +1,10 @@
-function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes, maintenanceRoutes, rangeSessionsRoutes, reportsRoutes }) {
+function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes, maintenanceRoutes, rangeSessionsRoutes, photosRoutes, reportsRoutes }) {
   app.use('/', authRoutes);
   app.use('/', homeRoutes);
   app.use('/firearms', firearmsRoutes);
   app.use('/firearms', maintenanceRoutes);
   app.use('/firearms', rangeSessionsRoutes);
+  app.use('/firearms', photosRoutes);
   app.use('/', reportsRoutes);
 }
 

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -1,7 +1,8 @@
-function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes, reportsRoutes }) {
+function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes, maintenanceRoutes, reportsRoutes }) {
   app.use('/', authRoutes);
   app.use('/', homeRoutes);
   app.use('/firearms', firearmsRoutes);
+  app.use('/firearms', maintenanceRoutes);
   app.use('/', reportsRoutes);
 }
 

--- a/src/app/routes/index.js
+++ b/src/app/routes/index.js
@@ -1,8 +1,9 @@
-function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes, maintenanceRoutes, reportsRoutes }) {
+function registerRoutes(app, { authRoutes, homeRoutes, firearmsRoutes, maintenanceRoutes, rangeSessionsRoutes, reportsRoutes }) {
   app.use('/', authRoutes);
   app.use('/', homeRoutes);
   app.use('/firearms', firearmsRoutes);
   app.use('/firearms', maintenanceRoutes);
+  app.use('/firearms', rangeSessionsRoutes);
   app.use('/', reportsRoutes);
 }
 

--- a/src/features/auth/auth.controller.js
+++ b/src/features/auth/auth.controller.js
@@ -13,6 +13,7 @@ function createAuthController(authService) {
       usernameValue: authService.getUsername(),
       themeValue: authService.getTheme(),
       updateCheckEnabled: authService.getUpdateCheckEnabled(),
+      maintenanceDueDaysValue: authService.getMaintenanceDueDays(),
       ...overrides
     };
   }
@@ -119,10 +120,13 @@ function createAuthController(authService) {
     },
 
     updatePreferences(req, res) {
-      const { theme, update_check_enabled } = req.body;
+      const { theme, update_check_enabled, maintenance_due_days } = req.body;
 
       try {
         authService.setTheme(theme);
+        if (maintenance_due_days !== undefined) {
+          authService.setMaintenanceDueDays(maintenance_due_days);
+        }
         if (res.locals.updateCheckAllowed) {
           authService.setUpdateCheckEnabled(update_check_enabled === '1');
         }

--- a/src/features/auth/auth.service.js
+++ b/src/features/auth/auth.service.js
@@ -1,5 +1,11 @@
 const bcrypt = require('bcrypt');
 const { timingSafeEqual } = require('crypto');
+const {
+  parseMaintenanceDueDays,
+  MAINTENANCE_DUE_SETTING_KEY,
+  MIN_CLEANING_DUE_DAYS,
+  MAX_CLEANING_DUE_DAYS
+} = require('../maintenance/maintenance.service');
 
 // A pre-computed bcrypt hash of an unguessable value, used to equalise the
 // wall-clock time of a wrong-username login with a wrong-password login.
@@ -98,6 +104,20 @@ function createAuthService({ adminUser, settingsRepository }) {
 
     setUpdateCheckEnabled(enabled) {
       settingsRepository.set('update_check_enabled', enabled ? '1' : '0');
+    },
+
+    getMaintenanceDueDays() {
+      return parseMaintenanceDueDays(settingsRepository.get(MAINTENANCE_DUE_SETTING_KEY));
+    },
+
+    setMaintenanceDueDays(value) {
+      const parsed = Number(String(value ?? '').trim());
+      if (!Number.isInteger(parsed) || parsed < MIN_CLEANING_DUE_DAYS || parsed > MAX_CLEANING_DUE_DAYS) {
+        throw new Error(
+          `Cleaning reminder must be a whole number of days between ${MIN_CLEANING_DUE_DAYS} and ${MAX_CLEANING_DUE_DAYS}.`
+        );
+      }
+      settingsRepository.set(MAINTENANCE_DUE_SETTING_KEY, String(parsed));
     }
   };
 }

--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -1,9 +1,10 @@
 const { sanitizeFirearmInput, validateFirearmInput } = require('./firearms.validators');
 const { CSV_HEADERS } = require('./firearms.service');
 const { MAINTENANCE_TYPES } = require('../maintenance/maintenance.validators');
+const { MAX_PHOTOS_PER_FIREARM } = require('../photos/photos.service');
 const { auditLog } = require('../../services/audit.service');
 
-function createFirearmsController(firearmsService, { maintenanceService, rangeSessionsService } = {}) {
+function createFirearmsController(firearmsService, { maintenanceService, rangeSessionsService, photosService } = {}) {
   return {
     list(req, res) {
       const userId = req.session.user?.id ?? 1;
@@ -102,6 +103,10 @@ function createFirearmsController(firearmsService, { maintenanceService, rangeSe
         viewModel.rangeSessions = rangeSessionsService.listByFirearm(item.id);
         viewModel.rangeTotals = rangeSessionsService.totalsForFirearm(item.id);
       }
+      if (photosService) {
+        viewModel.photos = photosService.listByFirearm(item.id);
+        viewModel.maxPhotos = MAX_PHOTOS_PER_FIREARM;
+      }
       return res.render('firearms/show', viewModel);
     },
 
@@ -167,6 +172,11 @@ function createFirearmsController(firearmsService, { maintenanceService, rangeSe
       const item = firearmsService.getById(req.params.id, userId);
       if (!item) {
         return res.status(404).render('errors/404');
+      }
+      // Photo files must be unlinked before the row goes away — the DB
+      // cascade removes the photo rows, not the files on disk.
+      if (photosService) {
+        photosService.removeAllForFirearm(item.id);
       }
       firearmsService.remove(req.params.id, userId);
       if (req.session) req.session.flash = { type: 'success', message: 'Firearm deleted.' };

--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -3,7 +3,7 @@ const { CSV_HEADERS } = require('./firearms.service');
 const { MAINTENANCE_TYPES } = require('../maintenance/maintenance.validators');
 const { auditLog } = require('../../services/audit.service');
 
-function createFirearmsController(firearmsService, { maintenanceService } = {}) {
+function createFirearmsController(firearmsService, { maintenanceService, rangeSessionsService } = {}) {
   return {
     list(req, res) {
       const userId = req.session.user?.id ?? 1;
@@ -97,6 +97,10 @@ function createFirearmsController(firearmsService, { maintenanceService } = {}) 
         viewModel.maintenance = maintenanceService.listByFirearm(item.id);
         viewModel.cleaningStatus = maintenanceService.getCleaningStatusForFirearm(item.id, item.status);
         viewModel.maintenanceTypes = MAINTENANCE_TYPES;
+      }
+      if (rangeSessionsService) {
+        viewModel.rangeSessions = rangeSessionsService.listByFirearm(item.id);
+        viewModel.rangeTotals = rangeSessionsService.totalsForFirearm(item.id);
       }
       return res.render('firearms/show', viewModel);
     },

--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -1,7 +1,7 @@
 const { sanitizeFirearmInput, validateFirearmInput } = require('./firearms.validators');
 const { CSV_HEADERS } = require('./firearms.service');
 const { MAINTENANCE_TYPES } = require('../maintenance/maintenance.validators');
-const { MAX_PHOTOS_PER_FIREARM } = require('../photos/photos.service');
+const { MAX_PHOTOS_PER_FIREARM, MAX_PHOTO_BYTES } = require('../photos/photos.service');
 const { auditLog } = require('../../services/audit.service');
 
 function createFirearmsController(firearmsService, { maintenanceService, rangeSessionsService, photosService } = {}) {
@@ -106,6 +106,7 @@ function createFirearmsController(firearmsService, { maintenanceService, rangeSe
       if (photosService) {
         viewModel.photos = photosService.listByFirearm(item.id);
         viewModel.maxPhotos = MAX_PHOTOS_PER_FIREARM;
+        viewModel.maxPhotoBytes = MAX_PHOTO_BYTES;
       }
       return res.render('firearms/show', viewModel);
     },

--- a/src/features/firearms/firearms.controller.js
+++ b/src/features/firearms/firearms.controller.js
@@ -1,8 +1,9 @@
 const { sanitizeFirearmInput, validateFirearmInput } = require('./firearms.validators');
 const { CSV_HEADERS } = require('./firearms.service');
+const { MAINTENANCE_TYPES } = require('../maintenance/maintenance.validators');
 const { auditLog } = require('../../services/audit.service');
 
-function createFirearmsController(firearmsService) {
+function createFirearmsController(firearmsService, { maintenanceService } = {}) {
   return {
     list(req, res) {
       const userId = req.session.user?.id ?? 1;
@@ -91,7 +92,13 @@ function createFirearmsController(firearmsService) {
       if (!item) {
         return res.status(404).render('errors/404');
       }
-      return res.render('firearms/show', { pageTitle: `${item.make} ${item.model}`, item });
+      const viewModel = { pageTitle: `${item.make} ${item.model}`, item };
+      if (maintenanceService) {
+        viewModel.maintenance = maintenanceService.listByFirearm(item.id);
+        viewModel.cleaningStatus = maintenanceService.getCleaningStatusForFirearm(item.id, item.status);
+        viewModel.maintenanceTypes = MAINTENANCE_TYPES;
+      }
+      return res.render('firearms/show', viewModel);
     },
 
     duplicate(req, res) {

--- a/src/features/home/home.controller.js
+++ b/src/features/home/home.controller.js
@@ -2,7 +2,8 @@ function createHomeController(homeService) {
   return {
     index(req, res) {
       const username = req.session.user?.username || 'admin';
-      const dashboard = homeService.getDashboard(username);
+      const userId = req.session.user?.id ?? 1;
+      const dashboard = homeService.getDashboard(username, userId);
 
       return res.render('home/index', { ...dashboard, pageTitle: 'Dashboard' });
     }

--- a/src/features/home/home.service.js
+++ b/src/features/home/home.service.js
@@ -2,7 +2,7 @@
 // If created_at and updated_at are within this threshold, we treat it as "Added".
 const UPDATE_DETECTION_THRESHOLD_MS = 5000;
 
-function createHomeService(firearmsRepository) {
+function createHomeService(firearmsRepository, maintenanceService) {
   function toRelativeTime(dateString) {
     if (!dateString) {
       return '—';
@@ -30,8 +30,11 @@ function createHomeService(firearmsRepository) {
   }
 
   return {
-    getDashboard(username) {
+    getDashboard(username, userId = 1) {
       const summary = firearmsRepository.getCollectionSummary();
+      const cleaning = maintenanceService
+        ? maintenanceService.getDueForCleaning(userId)
+        : { count: 0, items: [] };
       const recentRecords = firearmsRepository.getRecentActivity(5);
       const typeBreakdown = firearmsRepository.getTypeBreakdown();
       const valueByYear = firearmsRepository.getValueByYear();
@@ -57,13 +60,15 @@ function createHomeService(firearmsRepository) {
           totalFirearms: summary.total_firearms || 0,
           thisMonth: summary.this_month || 0,
           categories: summary.categories || 0,
-          lastUpdateDays: summary.last_update_days == null ? '—' : `${summary.last_update_days}d`
+          lastUpdateDays: summary.last_update_days == null ? '—' : `${summary.last_update_days}d`,
+          dueForCleaning: cleaning.count
         },
         charts: {
           typeBreakdown,
           valueByYear
         },
-        recentActivity
+        recentActivity,
+        cleaningDue: cleaning.items.slice(0, 5)
       };
     }
   };

--- a/src/features/maintenance/maintenance.controller.js
+++ b/src/features/maintenance/maintenance.controller.js
@@ -1,0 +1,53 @@
+const { sanitizeMaintenanceInput, validateMaintenanceInput } = require('./maintenance.validators');
+const { auditLog } = require('../../services/audit.service');
+
+function createMaintenanceController({ maintenanceService, firearmsService }) {
+  function loadFirearm(req, res) {
+    const userId = req.session.user?.id ?? 1;
+    const firearm = firearmsService.getById(req.params.firearmId, userId);
+    if (!firearm) {
+      res.status(404).render('errors/404');
+      return null;
+    }
+    return firearm;
+  }
+
+  return {
+    create(req, res) {
+      const firearm = loadFirearm(req, res);
+      if (!firearm) return undefined;
+
+      const data = sanitizeMaintenanceInput(req.body);
+      const { isValid, fieldErrors } = validateMaintenanceInput(data);
+
+      // The add form lives on the composite detail page, so validation errors
+      // surface as a flash on redirect instead of a re-rendered form.
+      if (!isValid) {
+        if (req.session) req.session.flash = { type: 'error', message: Object.values(fieldErrors)[0] };
+        return res.redirect(`/firearms/${firearm.id}#maintenance`);
+      }
+
+      const logId = maintenanceService.create(firearm.id, data);
+      if (req.session) req.session.flash = { type: 'success', message: 'Maintenance entry added.' };
+      auditLog('maintenance.create', { id: req.id, ip: req.ip, firearmId: firearm.id, logId });
+      return res.redirect(`/firearms/${firearm.id}#maintenance`);
+    },
+
+    remove(req, res) {
+      const firearm = loadFirearm(req, res);
+      if (!firearm) return undefined;
+
+      const existing = maintenanceService.get(req.params.logId, firearm.id);
+      if (!existing) {
+        return res.status(404).render('errors/404');
+      }
+
+      maintenanceService.remove(req.params.logId, firearm.id);
+      if (req.session) req.session.flash = { type: 'success', message: 'Maintenance entry deleted.' };
+      auditLog('maintenance.delete', { id: req.id, ip: req.ip, firearmId: firearm.id, logId: req.params.logId });
+      return res.redirect(`/firearms/${firearm.id}#maintenance`);
+    }
+  };
+}
+
+module.exports = { createMaintenanceController };

--- a/src/features/maintenance/maintenance.routes.js
+++ b/src/features/maintenance/maintenance.routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const { requireAuth } = require('../../app/middleware/auth');
+
+function createMaintenanceRoutes(maintenanceController) {
+  const router = express.Router();
+
+  router.post('/:firearmId/maintenance', requireAuth, maintenanceController.create);
+  router.post('/:firearmId/maintenance/:logId/delete', requireAuth, maintenanceController.remove);
+
+  return router;
+}
+
+module.exports = { createMaintenanceRoutes };

--- a/src/features/maintenance/maintenance.service.js
+++ b/src/features/maintenance/maintenance.service.js
@@ -85,6 +85,15 @@ function createMaintenanceService(maintenanceRepository, settingsRepository) {
         }
       }
 
+      // Most urgent first, so consumers can slice a meaningful top-N:
+      // fired-but-never-cleaned (no daysSince), then longest since cleaning.
+      items.sort((a, b) => {
+        if (a.daysSince === null && b.daysSince === null) return 0;
+        if (a.daysSince === null) return -1;
+        if (b.daysSince === null) return 1;
+        return b.daysSince - a.daysSince;
+      });
+
       return { count: items.length, items, thresholdDays };
     },
 

--- a/src/features/maintenance/maintenance.service.js
+++ b/src/features/maintenance/maintenance.service.js
@@ -1,0 +1,117 @@
+const { isDispositionStatus } = require('../firearms/firearms.validators');
+
+const MAINTENANCE_DUE_SETTING_KEY = 'maintenance_due_days';
+const DEFAULT_CLEANING_DUE_DAYS = 90;
+const MIN_CLEANING_DUE_DAYS = 1;
+const MAX_CLEANING_DUE_DAYS = 365;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function parseMaintenanceDueDays(raw) {
+  const parsed = Number(String(raw ?? '').trim());
+  if (Number.isInteger(parsed) && parsed >= MIN_CLEANING_DUE_DAYS && parsed <= MAX_CLEANING_DUE_DAYS) {
+    return parsed;
+  }
+  return DEFAULT_CLEANING_DUE_DAYS;
+}
+
+function daysSinceIsoDate(dateString, now) {
+  const timestamp = Date.parse(`${dateString}T00:00:00Z`);
+  if (Number.isNaN(timestamp)) {
+    return null;
+  }
+  return Math.floor((now - timestamp) / MS_PER_DAY);
+}
+
+// Dates are validated to YYYY-MM-DD on the way in, so string comparison is a
+// safe chronological comparison here.
+function evaluateCleaningDue({ last_cleaned, last_range }, thresholdDays, now) {
+  if (last_range && (!last_cleaned || last_range > last_cleaned)) {
+    return {
+      reason: 'Range session since last cleaning',
+      daysSince: last_cleaned ? daysSinceIsoDate(last_cleaned, now) : null
+    };
+  }
+
+  if (last_cleaned) {
+    const days = daysSinceIsoDate(last_cleaned, now);
+    if (days !== null && days >= thresholdDays) {
+      return { reason: `Last cleaned ${days} days ago`, daysSince: days };
+    }
+  }
+
+  return null;
+}
+
+function createMaintenanceService(maintenanceRepository, settingsRepository) {
+  function getDueDays() {
+    return parseMaintenanceDueDays(settingsRepository.get(MAINTENANCE_DUE_SETTING_KEY));
+  }
+
+  return {
+    listByFirearm(firearmId) {
+      return maintenanceRepository.listByFirearm(firearmId);
+    },
+
+    get(id, firearmId) {
+      return maintenanceRepository.get(id, firearmId);
+    },
+
+    create(firearmId, data) {
+      return maintenanceRepository.create({ ...data, firearm_id: firearmId });
+    },
+
+    remove(id, firearmId) {
+      maintenanceRepository.remove(id, firearmId);
+    },
+
+    getDueForCleaning(userId = 1) {
+      const thresholdDays = getDueDays();
+      const now = Date.now();
+      const items = [];
+
+      for (const row of maintenanceRepository.getCleaningStatus(userId)) {
+        if (isDispositionStatus(row.status)) {
+          continue;
+        }
+        const due = evaluateCleaningDue(row, thresholdDays, now);
+        if (due) {
+          items.push({
+            id: row.id,
+            label: `${row.make} ${row.model}`.trim(),
+            reason: due.reason,
+            daysSince: due.daysSince
+          });
+        }
+      }
+
+      return { count: items.length, items, thresholdDays };
+    },
+
+    getCleaningStatusForFirearm(firearmId, status) {
+      const thresholdDays = getDueDays();
+      if (isDispositionStatus(status)) {
+        return { due: false, reason: null, lastCleaned: null, thresholdDays };
+      }
+
+      const dates = maintenanceRepository.getFirearmCleaningDates(firearmId) || {};
+      const due = evaluateCleaningDue(dates, thresholdDays, Date.now());
+
+      return {
+        due: Boolean(due),
+        reason: due ? due.reason : null,
+        lastCleaned: dates.last_cleaned || null,
+        thresholdDays
+      };
+    }
+  };
+}
+
+module.exports = {
+  createMaintenanceService,
+  parseMaintenanceDueDays,
+  MAINTENANCE_DUE_SETTING_KEY,
+  DEFAULT_CLEANING_DUE_DAYS,
+  MIN_CLEANING_DUE_DAYS,
+  MAX_CLEANING_DUE_DAYS
+};

--- a/src/features/maintenance/maintenance.validators.js
+++ b/src/features/maintenance/maintenance.validators.js
@@ -1,0 +1,59 @@
+const { isValidIsoDate } = require('../../shared/utils/dates');
+
+const MAINTENANCE_TYPES = ['Cleaning', 'Repair', 'Part Replacement', 'Inspection', 'Other'];
+
+const NOTES_MAX_LENGTH = 2000;
+const MAX_ROUND_COUNT_DELTA = 100000;
+
+function sanitizeMaintenanceInput(body) {
+  const rawDelta = body.round_count_delta;
+  const hasDelta = rawDelta !== undefined && rawDelta !== null && String(rawDelta).trim() !== '';
+
+  return {
+    date: (body.date || '').trim(),
+    type: (body.type || '').trim(),
+    notes: (body.notes || '').trim(),
+    round_count_delta: hasDelta ? Number(rawDelta) : null
+  };
+}
+
+function validateMaintenanceInput(data) {
+  const fieldErrors = {};
+
+  if (!data.date) {
+    fieldErrors.date = 'Date is required.';
+  } else if (!isValidIsoDate(data.date)) {
+    fieldErrors.date = 'Date must be a valid date in YYYY-MM-DD format.';
+  }
+
+  if (!data.type) {
+    fieldErrors.type = 'Type is required.';
+  } else if (!MAINTENANCE_TYPES.includes(data.type)) {
+    fieldErrors.type = 'Type must be one of the listed maintenance types.';
+  }
+
+  if (data.notes.length > NOTES_MAX_LENGTH) {
+    fieldErrors.notes = `Notes must be ${NOTES_MAX_LENGTH} characters or fewer.`;
+  }
+
+  if (data.round_count_delta !== null) {
+    if (!Number.isInteger(data.round_count_delta)) {
+      fieldErrors.round_count_delta = 'Round count adjustment must be a whole number.';
+    } else if (Math.abs(data.round_count_delta) > MAX_ROUND_COUNT_DELTA) {
+      fieldErrors.round_count_delta = `Round count adjustment must be between -${MAX_ROUND_COUNT_DELTA} and ${MAX_ROUND_COUNT_DELTA}.`;
+    }
+  }
+
+  return {
+    isValid: Object.keys(fieldErrors).length === 0,
+    fieldErrors
+  };
+}
+
+module.exports = {
+  sanitizeMaintenanceInput,
+  validateMaintenanceInput,
+  MAINTENANCE_TYPES,
+  NOTES_MAX_LENGTH,
+  MAX_ROUND_COUNT_DELTA
+};

--- a/src/features/photos/photos.controller.js
+++ b/src/features/photos/photos.controller.js
@@ -1,0 +1,75 @@
+const { auditLog } = require('../../services/audit.service');
+
+const SAFE_FILENAME_PATTERN = /^[a-f0-9]{32}\.(jpg|png|webp|gif)$/;
+
+function createPhotosController({ photosService, firearmsService, photosDir }) {
+  function loadFirearm(req) {
+    const userId = req.session.user?.id ?? 1;
+    return firearmsService.getById(req.params.firearmId, userId);
+  }
+
+  return {
+    upload(req, res) {
+      const firearm = loadFirearm(req);
+      if (!firearm) {
+        return res.status(404).json({ error: 'Firearm not found.' });
+      }
+      if (!req.file) {
+        return res.status(400).json({ error: 'No photo received.' });
+      }
+
+      try {
+        const { id } = photosService.storePhoto(firearm.id, req.file);
+        auditLog('photo.upload', { id: req.id, ip: req.ip, firearmId: firearm.id, photoId: id });
+        return res.status(201).json({ id });
+      } catch (err) {
+        if (err.code === 'INVALID_FILE_TYPE' || err.code === 'PHOTO_LIMIT') {
+          return res.status(400).json({ error: err.message });
+        }
+        throw err;
+      }
+    },
+
+    serve(req, res) {
+      const firearm = loadFirearm(req);
+      if (!firearm) {
+        return res.status(404).render('errors/404');
+      }
+
+      const photo = photosService.get(req.params.photoId, firearm.id);
+      // The filename comes exclusively from the DB row; the pattern check is
+      // defense-in-depth on top of sendFile's root containment.
+      if (!photo || !SAFE_FILENAME_PATTERN.test(photo.filename)) {
+        return res.status(404).render('errors/404');
+      }
+
+      return res.sendFile(
+        photo.filename,
+        { root: photosDir, headers: { 'Cache-Control': 'private, max-age=86400' } },
+        (err) => {
+          if (err && !res.headersSent) {
+            res.status(404).render('errors/404');
+          }
+        }
+      );
+    },
+
+    remove(req, res) {
+      const firearm = loadFirearm(req);
+      if (!firearm) {
+        return res.status(404).render('errors/404');
+      }
+
+      const removed = photosService.removePhoto(req.params.photoId, firearm.id);
+      if (!removed) {
+        return res.status(404).render('errors/404');
+      }
+
+      if (req.session) req.session.flash = { type: 'success', message: 'Photo deleted.' };
+      auditLog('photo.delete', { id: req.id, ip: req.ip, firearmId: firearm.id, photoId: req.params.photoId });
+      return res.redirect(`/firearms/${firearm.id}#photos`);
+    }
+  };
+}
+
+module.exports = { createPhotosController };

--- a/src/features/photos/photos.controller.js
+++ b/src/features/photos/photos.controller.js
@@ -9,7 +9,7 @@ function createPhotosController({ photosService, firearmsService, photosDir }) {
   }
 
   return {
-    upload(req, res) {
+    async upload(req, res) {
       const firearm = loadFirearm(req);
       if (!firearm) {
         return res.status(404).json({ error: 'Firearm not found.' });
@@ -19,7 +19,7 @@ function createPhotosController({ photosService, firearmsService, photosDir }) {
       }
 
       try {
-        const { id } = photosService.storePhoto(firearm.id, req.file);
+        const { id } = await photosService.storePhoto(firearm.id, req.file);
         auditLog('photo.upload', { id: req.id, ip: req.ip, firearmId: firearm.id, photoId: id });
         return res.status(201).json({ id });
       } catch (err) {

--- a/src/features/photos/photos.routes.js
+++ b/src/features/photos/photos.routes.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const multer = require('multer');
+const { requireAuth } = require('../../app/middleware/auth');
+const { ALLOWED_MIME_TYPES, MAX_PHOTO_BYTES } = require('./photos.service');
+
+function createPhotosRoutes(photosController) {
+  const router = express.Router();
+
+  const upload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: MAX_PHOTO_BYTES, files: 1 },
+    fileFilter(req, file, cb) {
+      if (ALLOWED_MIME_TYPES[file.mimetype]) {
+        return cb(null, true);
+      }
+      return cb(
+        Object.assign(new Error('Only JPEG, PNG, WebP, and GIF images are allowed.'), {
+          code: 'INVALID_FILE_TYPE'
+        })
+      );
+    }
+  });
+
+  router.post('/:firearmId/photos', requireAuth, upload.single('photo'), photosController.upload);
+  router.get('/:firearmId/photos/:photoId', requireAuth, photosController.serve);
+  router.post('/:firearmId/photos/:photoId/delete', requireAuth, photosController.remove);
+
+  // The upload is AJAX-only (the CSRF token must travel in a header), so
+  // multer errors are translated into JSON 400s for the client.
+  router.use((err, req, res, next) => {
+    if (err && err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ error: `Photos must be ${MAX_PHOTO_BYTES / (1024 * 1024)} MB or smaller.` });
+    }
+    if (err && err.code === 'INVALID_FILE_TYPE') {
+      return res.status(400).json({ error: err.message });
+    }
+    return next(err);
+  });
+
+  return router;
+}
+
+module.exports = { createPhotosRoutes };

--- a/src/features/photos/photos.routes.js
+++ b/src/features/photos/photos.routes.js
@@ -16,12 +16,14 @@ function createPhotosRoutes(photosController) {
     message: 'Too many photo requests. Please try again in 15 minutes.'
   });
 
+  // JSON body so the AJAX upload client can surface the message; the
+  // form-based delete route shares the limiter and tolerates JSON on 429.
   const photoWriteLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,
     max: 60,
     standardHeaders: true,
     legacyHeaders: false,
-    message: 'Too many photo changes. Please try again in 15 minutes.'
+    message: { error: 'Too many photo changes. Please try again in 15 minutes.' }
   });
 
   const router = express.Router();

--- a/src/features/photos/photos.routes.js
+++ b/src/features/photos/photos.routes.js
@@ -1,9 +1,29 @@
 const express = require('express');
 const multer = require('multer');
+const rateLimit = require('express-rate-limit');
 const { requireAuth } = require('../../app/middleware/auth');
 const { ALLOWED_MIME_TYPES, MAX_PHOTO_BYTES } = require('./photos.service');
 
 function createPhotosRoutes(photosController) {
+  // Limiters are created per-app so each createApp() call gets its own
+  // in-memory store, mirroring auth.routes.js. Serving stays generous
+  // (a full gallery is 12 image requests per detail-page view).
+  const photoReadLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 500,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: 'Too many photo requests. Please try again in 15 minutes.'
+  });
+
+  const photoWriteLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: 'Too many photo changes. Please try again in 15 minutes.'
+  });
+
   const router = express.Router();
 
   const upload = multer({
@@ -21,9 +41,9 @@ function createPhotosRoutes(photosController) {
     }
   });
 
-  router.post('/:firearmId/photos', requireAuth, upload.single('photo'), photosController.upload);
-  router.get('/:firearmId/photos/:photoId', requireAuth, photosController.serve);
-  router.post('/:firearmId/photos/:photoId/delete', requireAuth, photosController.remove);
+  router.post('/:firearmId/photos', requireAuth, photoWriteLimiter, upload.single('photo'), photosController.upload);
+  router.get('/:firearmId/photos/:photoId', requireAuth, photoReadLimiter, photosController.serve);
+  router.post('/:firearmId/photos/:photoId/delete', requireAuth, photoWriteLimiter, photosController.remove);
 
   // The upload is AJAX-only (the CSRF token must travel in a header), so
   // multer errors are translated into JSON 400s for the client.

--- a/src/features/photos/photos.service.js
+++ b/src/features/photos/photos.service.js
@@ -37,7 +37,9 @@ function createPhotosService({ photosRepository, photosDir }) {
       return photosRepository.countForFirearm(firearmId);
     },
 
-    storePhoto(firearmId, file) {
+    // Async because the image write is the one file operation here big enough
+    // (up to 10 MB) to block the event loop.
+    async storePhoto(firearmId, file) {
       const extension = ALLOWED_MIME_TYPES[file.mimetype];
       if (!extension) {
         throw Object.assign(new Error('Only JPEG, PNG, WebP, and GIF images are allowed.'), {
@@ -54,8 +56,8 @@ function createPhotosService({ photosRepository, photosDir }) {
       // Filenames are always generated server-side; the client name is kept
       // only as display metadata.
       const filename = `${crypto.randomBytes(16).toString('hex')}.${extension}`;
-      fs.mkdirSync(photosDir, { recursive: true });
-      fs.writeFileSync(absolutePath(filename), file.buffer);
+      await fs.promises.mkdir(photosDir, { recursive: true });
+      await fs.promises.writeFile(absolutePath(filename), file.buffer);
 
       try {
         const id = photosRepository.create({

--- a/src/features/photos/photos.service.js
+++ b/src/features/photos/photos.service.js
@@ -1,0 +1,103 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const ALLOWED_MIME_TYPES = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif'
+};
+const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
+const MAX_PHOTOS_PER_FIREARM = 12;
+
+function createPhotosService({ photosRepository, photosDir }) {
+  function absolutePath(filename) {
+    return path.join(photosDir, filename);
+  }
+
+  function unlinkQuietly(filename) {
+    try {
+      fs.unlinkSync(absolutePath(filename));
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err;
+    }
+  }
+
+  return {
+    listByFirearm(firearmId) {
+      return photosRepository.listByFirearm(firearmId);
+    },
+
+    get(id, firearmId) {
+      return photosRepository.get(id, firearmId);
+    },
+
+    countForFirearm(firearmId) {
+      return photosRepository.countForFirearm(firearmId);
+    },
+
+    storePhoto(firearmId, file) {
+      const extension = ALLOWED_MIME_TYPES[file.mimetype];
+      if (!extension) {
+        throw Object.assign(new Error('Only JPEG, PNG, WebP, and GIF images are allowed.'), {
+          code: 'INVALID_FILE_TYPE'
+        });
+      }
+
+      if (photosRepository.countForFirearm(firearmId) >= MAX_PHOTOS_PER_FIREARM) {
+        throw Object.assign(new Error(`A firearm can have at most ${MAX_PHOTOS_PER_FIREARM} photos.`), {
+          code: 'PHOTO_LIMIT'
+        });
+      }
+
+      // Filenames are always generated server-side; the client name is kept
+      // only as display metadata.
+      const filename = `${crypto.randomBytes(16).toString('hex')}.${extension}`;
+      fs.mkdirSync(photosDir, { recursive: true });
+      fs.writeFileSync(absolutePath(filename), file.buffer);
+
+      try {
+        const id = photosRepository.create({
+          firearm_id: firearmId,
+          filename,
+          original_name: file.originalname || '',
+          mime: file.mimetype,
+          size: file.size ?? file.buffer.length
+        });
+        return { id, filename };
+      } catch (err) {
+        unlinkQuietly(filename);
+        throw err;
+      }
+    },
+
+    removePhoto(id, firearmId) {
+      const photo = photosRepository.get(id, firearmId);
+      if (!photo) {
+        return false;
+      }
+      photosRepository.remove(id, firearmId);
+      unlinkQuietly(photo.filename);
+      return true;
+    },
+
+    // The DB rows cascade when the firearm row goes, but the files do not —
+    // call this before deleting the firearm so the filenames are still known.
+    removeAllForFirearm(firearmId) {
+      const photos = photosRepository.listByFirearm(firearmId);
+      for (const photo of photos) {
+        unlinkQuietly(photo.filename);
+      }
+      photosRepository.removeByFirearm(firearmId);
+      return photos.length;
+    }
+  };
+}
+
+module.exports = {
+  createPhotosService,
+  ALLOWED_MIME_TYPES,
+  MAX_PHOTO_BYTES,
+  MAX_PHOTOS_PER_FIREARM
+};

--- a/src/features/photos/photos.service.js
+++ b/src/features/photos/photos.service.js
@@ -57,7 +57,9 @@ function createPhotosService({ photosRepository, photosDir }) {
       // only as display metadata.
       const filename = `${crypto.randomBytes(16).toString('hex')}.${extension}`;
       await fs.promises.mkdir(photosDir, { recursive: true });
-      await fs.promises.writeFile(absolutePath(filename), file.buffer);
+      // 'wx' refuses to overwrite: on a (vanishingly unlikely) name collision
+      // the upload fails instead of clobbering another photo's file.
+      await fs.promises.writeFile(absolutePath(filename), file.buffer, { flag: 'wx' });
 
       let id;
       try {

--- a/src/features/photos/photos.service.js
+++ b/src/features/photos/photos.service.js
@@ -59,19 +59,34 @@ function createPhotosService({ photosRepository, photosDir }) {
       await fs.promises.mkdir(photosDir, { recursive: true });
       await fs.promises.writeFile(absolutePath(filename), file.buffer);
 
+      let id;
       try {
-        const id = photosRepository.create({
-          firearm_id: firearmId,
-          filename,
-          original_name: file.originalname || '',
-          mime: file.mimetype,
-          size: file.size ?? file.buffer.length
-        });
-        return { id, filename };
+        // The cap is re-checked atomically at insert time: the await above
+        // yields the event loop, so a concurrent upload may have landed since
+        // the early check.
+        id = photosRepository.createIfUnderCap(
+          {
+            firearm_id: firearmId,
+            filename,
+            original_name: file.originalname || '',
+            mime: file.mimetype,
+            size: file.size ?? file.buffer.length
+          },
+          MAX_PHOTOS_PER_FIREARM
+        );
       } catch (err) {
         unlinkQuietly(filename);
         throw err;
       }
+
+      if (id == null) {
+        unlinkQuietly(filename);
+        throw Object.assign(new Error(`A firearm can have at most ${MAX_PHOTOS_PER_FIREARM} photos.`), {
+          code: 'PHOTO_LIMIT'
+        });
+      }
+
+      return { id, filename };
     },
 
     removePhoto(id, firearmId) {

--- a/src/features/photos/photos.service.js
+++ b/src/features/photos/photos.service.js
@@ -79,8 +79,10 @@ function createPhotosService({ photosRepository, photosDir }) {
       if (!photo) {
         return false;
       }
-      photosRepository.remove(id, firearmId);
+      // Unlink before touching the row: if the unlink fails the request
+      // errors with nothing deleted, instead of orphaning the file.
       unlinkQuietly(photo.filename);
+      photosRepository.remove(id, firearmId);
       return true;
     },
 

--- a/src/features/range-sessions/range-sessions.controller.js
+++ b/src/features/range-sessions/range-sessions.controller.js
@@ -1,0 +1,53 @@
+const { sanitizeRangeSessionInput, validateRangeSessionInput } = require('./range-sessions.validators');
+const { auditLog } = require('../../services/audit.service');
+
+function createRangeSessionsController({ rangeSessionsService, firearmsService }) {
+  function loadFirearm(req, res) {
+    const userId = req.session.user?.id ?? 1;
+    const firearm = firearmsService.getById(req.params.firearmId, userId);
+    if (!firearm) {
+      res.status(404).render('errors/404');
+      return null;
+    }
+    return firearm;
+  }
+
+  return {
+    create(req, res) {
+      const firearm = loadFirearm(req, res);
+      if (!firearm) return undefined;
+
+      const data = sanitizeRangeSessionInput(req.body);
+      const { isValid, fieldErrors } = validateRangeSessionInput(data);
+
+      // The add form lives on the composite detail page, so validation errors
+      // surface as a flash on redirect instead of a re-rendered form.
+      if (!isValid) {
+        if (req.session) req.session.flash = { type: 'error', message: Object.values(fieldErrors)[0] };
+        return res.redirect(`/firearms/${firearm.id}#range-sessions`);
+      }
+
+      const sessionId = rangeSessionsService.create(firearm.id, data);
+      if (req.session) req.session.flash = { type: 'success', message: 'Range session added.' };
+      auditLog('rangeSession.create', { id: req.id, ip: req.ip, firearmId: firearm.id, sessionId });
+      return res.redirect(`/firearms/${firearm.id}#range-sessions`);
+    },
+
+    remove(req, res) {
+      const firearm = loadFirearm(req, res);
+      if (!firearm) return undefined;
+
+      const existing = rangeSessionsService.get(req.params.sessionId, firearm.id);
+      if (!existing) {
+        return res.status(404).render('errors/404');
+      }
+
+      rangeSessionsService.remove(req.params.sessionId, firearm.id);
+      if (req.session) req.session.flash = { type: 'success', message: 'Range session deleted.' };
+      auditLog('rangeSession.delete', { id: req.id, ip: req.ip, firearmId: firearm.id, sessionId: req.params.sessionId });
+      return res.redirect(`/firearms/${firearm.id}#range-sessions`);
+    }
+  };
+}
+
+module.exports = { createRangeSessionsController };

--- a/src/features/range-sessions/range-sessions.routes.js
+++ b/src/features/range-sessions/range-sessions.routes.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const { requireAuth } = require('../../app/middleware/auth');
+
+function createRangeSessionsRoutes(rangeSessionsController) {
+  const router = express.Router();
+
+  router.post('/:firearmId/range-sessions', requireAuth, rangeSessionsController.create);
+  router.post('/:firearmId/range-sessions/:sessionId/delete', requireAuth, rangeSessionsController.remove);
+
+  return router;
+}
+
+module.exports = { createRangeSessionsRoutes };

--- a/src/features/range-sessions/range-sessions.service.js
+++ b/src/features/range-sessions/range-sessions.service.js
@@ -1,0 +1,25 @@
+function createRangeSessionsService(rangeSessionsRepository) {
+  return {
+    listByFirearm(firearmId) {
+      return rangeSessionsRepository.listByFirearm(firearmId);
+    },
+
+    get(id, firearmId) {
+      return rangeSessionsRepository.get(id, firearmId);
+    },
+
+    create(firearmId, data) {
+      return rangeSessionsRepository.create({ ...data, firearm_id: firearmId });
+    },
+
+    remove(id, firearmId) {
+      rangeSessionsRepository.remove(id, firearmId);
+    },
+
+    totalsForFirearm(firearmId) {
+      return rangeSessionsRepository.totalsForFirearm(firearmId);
+    }
+  };
+}
+
+module.exports = { createRangeSessionsService };

--- a/src/features/range-sessions/range-sessions.validators.js
+++ b/src/features/range-sessions/range-sessions.validators.js
@@ -1,0 +1,58 @@
+const { isValidIsoDate } = require('../../shared/utils/dates');
+
+const LOCATION_MAX_LENGTH = 100;
+const NOTES_MAX_LENGTH = 2000;
+const MAX_ROUNDS_FIRED = 100000;
+
+function sanitizeRangeSessionInput(body) {
+  const rawRounds = body.rounds_fired;
+  const hasRounds = rawRounds !== undefined && rawRounds !== null && String(rawRounds).trim() !== '';
+
+  return {
+    date: (body.date || '').trim(),
+    location: (body.location || '').trim(),
+    rounds_fired: hasRounds ? Number(rawRounds) : null,
+    notes: (body.notes || '').trim()
+  };
+}
+
+function validateRangeSessionInput(data) {
+  const fieldErrors = {};
+
+  if (!data.date) {
+    fieldErrors.date = 'Date is required.';
+  } else if (!isValidIsoDate(data.date)) {
+    fieldErrors.date = 'Date must be a valid date in YYYY-MM-DD format.';
+  }
+
+  if (data.location.length > LOCATION_MAX_LENGTH) {
+    fieldErrors.location = `Location must be ${LOCATION_MAX_LENGTH} characters or fewer.`;
+  }
+
+  if (data.notes.length > NOTES_MAX_LENGTH) {
+    fieldErrors.notes = `Notes must be ${NOTES_MAX_LENGTH} characters or fewer.`;
+  }
+
+  if (data.rounds_fired !== null) {
+    if (!Number.isInteger(data.rounds_fired)) {
+      fieldErrors.rounds_fired = 'Rounds fired must be a whole number.';
+    } else if (data.rounds_fired < 0) {
+      fieldErrors.rounds_fired = 'Rounds fired cannot be negative.';
+    } else if (data.rounds_fired > MAX_ROUNDS_FIRED) {
+      fieldErrors.rounds_fired = `Rounds fired must be ${MAX_ROUNDS_FIRED} or less.`;
+    }
+  }
+
+  return {
+    isValid: Object.keys(fieldErrors).length === 0,
+    fieldErrors
+  };
+}
+
+module.exports = {
+  sanitizeRangeSessionInput,
+  validateRangeSessionInput,
+  LOCATION_MAX_LENGTH,
+  NOTES_MAX_LENGTH,
+  MAX_ROUNDS_FIRED
+};

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -71,7 +71,9 @@ function getConfig() {
 function resolveDatabasePath(rawPath, rawDataDir) {
   const defaultDir = path.join(process.cwd(), 'data');
   const allowed = path.resolve(rawDataDir || defaultDir);
-  const resolved = path.resolve(rawPath || path.join(defaultDir, 'app.db'));
+  // Default the database file inside the allowed base so setting DATA_DIR
+  // alone works without also having to set DATABASE_PATH.
+  const resolved = path.resolve(rawPath || path.join(allowed, 'app.db'));
 
   if (resolved !== allowed && !resolved.startsWith(allowed + path.sep)) {
     throw new Error(

--- a/src/infra/config/index.js
+++ b/src/infra/config/index.js
@@ -50,6 +50,7 @@ function getConfig() {
     });
   }
 
+  const dataDir = path.resolve(process.env.DATA_DIR || path.join(process.cwd(), 'data'));
   const databasePath = resolveDatabasePath(process.env.DATABASE_PATH, process.env.DATA_DIR);
 
   return {
@@ -58,6 +59,8 @@ function getConfig() {
     adminUser: process.env.ADMIN_USERNAME || 'admin',
     adminPass,
     databasePath,
+    dataDir,
+    photosDir: path.join(dataDir, 'photos'),
     trustProxy,
     secureCookies,
     isProduction,

--- a/src/infra/db/migrations/007_firearm_photos.sql
+++ b/src/infra/db/migrations/007_firearm_photos.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS firearm_photos (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  firearm_id INTEGER NOT NULL,
+  filename TEXT NOT NULL UNIQUE,
+  original_name TEXT,
+  mime TEXT NOT NULL,
+  size INTEGER NOT NULL,
+  created_at TEXT DEFAULT (datetime('now')),
+  FOREIGN KEY (firearm_id) REFERENCES firearms(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_firearm_photos_firearm_id ON firearm_photos(firearm_id);

--- a/src/infra/db/migrations/008_log_indexes.sql
+++ b/src/infra/db/migrations/008_log_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_maintenance_logs_firearm_type_date ON maintenance_logs(firearm_id, type, date);
+CREATE INDEX IF NOT EXISTS idx_range_sessions_firearm_date        ON range_sessions(firearm_id, date);

--- a/src/infra/db/repositories/maintenance.repository.js
+++ b/src/infra/db/repositories/maintenance.repository.js
@@ -29,7 +29,9 @@ function createMaintenanceRepository(db) {
           f.model,
           f.status,
           (SELECT MAX(m.date) FROM maintenance_logs m WHERE m.firearm_id = f.id AND m.type = 'Cleaning') AS last_cleaned,
-          (SELECT MAX(r.date) FROM range_sessions r WHERE r.firearm_id = f.id) AS last_range
+          (SELECT MAX(r.date) FROM range_sessions r
+            WHERE r.firearm_id = f.id
+              AND (r.rounds_fired IS NULL OR r.rounds_fired != 0)) AS last_range
         FROM firearms f
         WHERE f.user_id = ?
         ORDER BY f.make, f.model, f.id
@@ -39,7 +41,9 @@ function createMaintenanceRepository(db) {
       return db.prepare(`
         SELECT
           (SELECT MAX(m.date) FROM maintenance_logs m WHERE m.firearm_id = @firearmId AND m.type = 'Cleaning') AS last_cleaned,
-          (SELECT MAX(r.date) FROM range_sessions r WHERE r.firearm_id = @firearmId) AS last_range
+          (SELECT MAX(r.date) FROM range_sessions r
+            WHERE r.firearm_id = @firearmId
+              AND (r.rounds_fired IS NULL OR r.rounds_fired != 0)) AS last_range
       `).get({ firearmId });
     }
   };

--- a/src/infra/db/repositories/maintenance.repository.js
+++ b/src/infra/db/repositories/maintenance.repository.js
@@ -1,0 +1,48 @@
+function createMaintenanceRepository(db) {
+  return {
+    listByFirearm(firearmId) {
+      return db
+        .prepare('SELECT * FROM maintenance_logs WHERE firearm_id = ? ORDER BY date DESC, id DESC')
+        .all(firearmId);
+    },
+    get(id, firearmId) {
+      return db
+        .prepare('SELECT * FROM maintenance_logs WHERE id = ? AND firearm_id = ?')
+        .get(id, firearmId);
+    },
+    create(data) {
+      const stmt = db.prepare(`
+        INSERT INTO maintenance_logs (firearm_id, date, type, notes, round_count_delta)
+        VALUES (@firearm_id, @date, @type, @notes, @round_count_delta)
+      `);
+      const info = stmt.run({ notes: '', round_count_delta: null, ...data });
+      return info.lastInsertRowid;
+    },
+    remove(id, firearmId) {
+      db.prepare('DELETE FROM maintenance_logs WHERE id = ? AND firearm_id = ?').run(id, firearmId);
+    },
+    getCleaningStatus(userId = 1) {
+      return db.prepare(`
+        SELECT
+          f.id,
+          f.make,
+          f.model,
+          f.status,
+          (SELECT MAX(m.date) FROM maintenance_logs m WHERE m.firearm_id = f.id AND m.type = 'Cleaning') AS last_cleaned,
+          (SELECT MAX(r.date) FROM range_sessions r WHERE r.firearm_id = f.id) AS last_range
+        FROM firearms f
+        WHERE f.user_id = ?
+        ORDER BY f.make, f.model, f.id
+      `).all(userId);
+    },
+    getFirearmCleaningDates(firearmId) {
+      return db.prepare(`
+        SELECT
+          (SELECT MAX(m.date) FROM maintenance_logs m WHERE m.firearm_id = @firearmId AND m.type = 'Cleaning') AS last_cleaned,
+          (SELECT MAX(r.date) FROM range_sessions r WHERE r.firearm_id = @firearmId) AS last_range
+      `).get({ firearmId });
+    }
+  };
+}
+
+module.exports = { createMaintenanceRepository };

--- a/src/infra/db/repositories/photos.repository.js
+++ b/src/infra/db/repositories/photos.repository.js
@@ -1,0 +1,35 @@
+function createPhotosRepository(db) {
+  return {
+    listByFirearm(firearmId) {
+      return db
+        .prepare('SELECT * FROM firearm_photos WHERE firearm_id = ? ORDER BY created_at ASC, id ASC')
+        .all(firearmId);
+    },
+    get(id, firearmId) {
+      return db
+        .prepare('SELECT * FROM firearm_photos WHERE id = ? AND firearm_id = ?')
+        .get(id, firearmId);
+    },
+    countForFirearm(firearmId) {
+      return db
+        .prepare('SELECT COUNT(*) AS count FROM firearm_photos WHERE firearm_id = ?')
+        .get(firearmId).count;
+    },
+    create(data) {
+      const stmt = db.prepare(`
+        INSERT INTO firearm_photos (firearm_id, filename, original_name, mime, size)
+        VALUES (@firearm_id, @filename, @original_name, @mime, @size)
+      `);
+      const info = stmt.run({ original_name: '', ...data });
+      return info.lastInsertRowid;
+    },
+    remove(id, firearmId) {
+      db.prepare('DELETE FROM firearm_photos WHERE id = ? AND firearm_id = ?').run(id, firearmId);
+    },
+    removeByFirearm(firearmId) {
+      db.prepare('DELETE FROM firearm_photos WHERE firearm_id = ?').run(firearmId);
+    }
+  };
+}
+
+module.exports = { createPhotosRepository };

--- a/src/infra/db/repositories/photos.repository.js
+++ b/src/infra/db/repositories/photos.repository.js
@@ -1,4 +1,28 @@
 function createPhotosRepository(db) {
+  function insertPhoto(data) {
+    const stmt = db.prepare(`
+      INSERT INTO firearm_photos (firearm_id, filename, original_name, mime, size)
+      VALUES (@firearm_id, @filename, @original_name, @mime, @size)
+    `);
+    const info = stmt.run({ original_name: '', ...data });
+    return info.lastInsertRowid;
+  }
+
+  function countPhotos(firearmId) {
+    return db
+      .prepare('SELECT COUNT(*) AS count FROM firearm_photos WHERE firearm_id = ?')
+      .get(firearmId).count;
+  }
+
+  // Count + insert run inside one transaction so concurrent uploads cannot
+  // both pass the cap check. Returns null when the firearm is at the cap.
+  const insertIfUnderCap = db.transaction((data, maxPerFirearm) => {
+    if (countPhotos(data.firearm_id) >= maxPerFirearm) {
+      return null;
+    }
+    return insertPhoto(data);
+  });
+
   return {
     listByFirearm(firearmId) {
       return db
@@ -11,17 +35,13 @@ function createPhotosRepository(db) {
         .get(id, firearmId);
     },
     countForFirearm(firearmId) {
-      return db
-        .prepare('SELECT COUNT(*) AS count FROM firearm_photos WHERE firearm_id = ?')
-        .get(firearmId).count;
+      return countPhotos(firearmId);
     },
     create(data) {
-      const stmt = db.prepare(`
-        INSERT INTO firearm_photos (firearm_id, filename, original_name, mime, size)
-        VALUES (@firearm_id, @filename, @original_name, @mime, @size)
-      `);
-      const info = stmt.run({ original_name: '', ...data });
-      return info.lastInsertRowid;
+      return insertPhoto(data);
+    },
+    createIfUnderCap(data, maxPerFirearm) {
+      return insertIfUnderCap(data, maxPerFirearm);
     },
     remove(id, firearmId) {
       db.prepare('DELETE FROM firearm_photos WHERE id = ? AND firearm_id = ?').run(id, firearmId);

--- a/src/infra/db/repositories/range-sessions.repository.js
+++ b/src/infra/db/repositories/range-sessions.repository.js
@@ -1,0 +1,36 @@
+function createRangeSessionsRepository(db) {
+  return {
+    listByFirearm(firearmId) {
+      return db
+        .prepare('SELECT * FROM range_sessions WHERE firearm_id = ? ORDER BY date DESC, id DESC')
+        .all(firearmId);
+    },
+    get(id, firearmId) {
+      return db
+        .prepare('SELECT * FROM range_sessions WHERE id = ? AND firearm_id = ?')
+        .get(id, firearmId);
+    },
+    create(data) {
+      const stmt = db.prepare(`
+        INSERT INTO range_sessions (firearm_id, date, location, rounds_fired, notes)
+        VALUES (@firearm_id, @date, @location, @rounds_fired, @notes)
+      `);
+      const info = stmt.run({ location: '', rounds_fired: null, notes: '', ...data });
+      return info.lastInsertRowid;
+    },
+    remove(id, firearmId) {
+      db.prepare('DELETE FROM range_sessions WHERE id = ? AND firearm_id = ?').run(id, firearmId);
+    },
+    totalsForFirearm(firearmId) {
+      return db
+        .prepare(`
+          SELECT COUNT(*) AS session_count, COALESCE(SUM(rounds_fired), 0) AS total_rounds
+          FROM range_sessions
+          WHERE firearm_id = ?
+        `)
+        .get(firearmId);
+    }
+  };
+}
+
+module.exports = { createRangeSessionsRepository };

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -2031,9 +2031,58 @@ details.filter-group[open] > summary::after {
   margin-top: 0;
 }
 
+/* Photo gallery on the firearm detail page */
+.photo-upload-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 12px 0;
+}
+
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.photo-item {
+  position: relative;
+}
+
+.photo-thumb {
+  display: block;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.photo-thumb img {
+  display: block;
+  width: 100%;
+  aspect-ratio: 1;
+  object-fit: cover;
+}
+
+.photo-delete-form {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  margin: 0;
+}
+
+.photo-delete {
+  padding: 2px 10px;
+  line-height: 1.4;
+}
+
 @media (max-width: 640px) {
   .log-form {
     grid-template-columns: 1fr;
+  }
+
+  .photo-grid {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
   }
 
   .settings-grid {

--- a/src/public/css/styles.css
+++ b/src/public/css/styles.css
@@ -1984,7 +1984,58 @@ details.filter-group[open] > summary::after {
   }
 }
 
+/* Log sections (maintenance / range sessions) on the firearm detail page */
+.log-section-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.log-section-header .section-header {
+  margin: 0;
+}
+
+.log-due-reason {
+  margin: 4px 0 12px;
+}
+
+.log-add {
+  margin: 12px 0 16px;
+}
+
+.log-add summary {
+  cursor: pointer;
+  color: var(--accent);
+  font-weight: 600;
+  width: fit-content;
+}
+
+.log-add summary:hover {
+  text-decoration: underline;
+}
+
+.log-add[open] summary {
+  margin-bottom: 12px;
+}
+
+.log-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  align-items: end;
+}
+
+.log-form .log-form-actions {
+  grid-column: 1 / -1;
+  margin-top: 0;
+}
+
 @media (max-width: 640px) {
+  .log-form {
+    grid-template-columns: 1fr;
+  }
+
   .settings-grid {
     grid-template-columns: 1fr;
   }

--- a/src/public/js/firearm-photos.js
+++ b/src/public/js/firearm-photos.js
@@ -23,7 +23,7 @@
       return;
     }
     if (file.size > MAX_BYTES) {
-      showError('Photos must be ' + MAX_MB + ' MB or smaller.');
+      showError(`Photos must be ${MAX_MB} MB or smaller.`);
       return;
     }
 

--- a/src/public/js/firearm-photos.js
+++ b/src/public/js/firearm-photos.js
@@ -1,0 +1,57 @@
+// Photo upload for the firearm detail page. The CSRF token travels in a
+// header because multipart bodies are parsed after the CSRF check runs.
+(function () {
+  const input = document.querySelector('[data-photo-input]');
+  const button = document.querySelector('[data-photo-upload]');
+  const errorEl = document.querySelector('[data-photo-error]');
+  if (!input || !button) return;
+
+  const csrfToken = document.getElementById('csrf-token').value;
+  const MAX_BYTES = 10 * 1024 * 1024; // 10 MB — matches the server upload limit
+
+  function showError(message) {
+    errorEl.textContent = message;
+    errorEl.hidden = false;
+  }
+
+  button.addEventListener('click', function () {
+    const file = input.files[0];
+    if (!file) {
+      showError('Choose an image first.');
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      showError('Photos must be 10 MB or smaller.');
+      return;
+    }
+
+    errorEl.hidden = true;
+    button.disabled = true;
+    button.textContent = 'Uploading…';
+
+    const formData = new FormData();
+    formData.append('photo', file);
+
+    fetch(button.getAttribute('data-photo-url'), {
+      method: 'POST',
+      headers: { 'x-csrf-token': csrfToken },
+      body: formData
+    })
+      .then(function (response) {
+        if (response.ok) {
+          window.location.reload();
+          return null;
+        }
+        return response.json().then(function (data) {
+          showError((data && data.error) || 'Upload failed. Please try again.');
+        });
+      })
+      .catch(function () {
+        showError('Upload failed. Please try again.');
+      })
+      .finally(function () {
+        button.disabled = false;
+        button.textContent = 'Upload';
+      });
+  });
+}());

--- a/src/public/js/firearm-photos.js
+++ b/src/public/js/firearm-photos.js
@@ -7,7 +7,9 @@
   if (!input || !button) return;
 
   const csrfToken = document.getElementById('csrf-token').value;
-  const MAX_BYTES = 10 * 1024 * 1024; // 10 MB — matches the server upload limit
+  // The authoritative limit lives on the server and is rendered onto the button.
+  const MAX_BYTES = Number(button.getAttribute('data-max-bytes')) || 10 * 1024 * 1024;
+  const MAX_MB = Math.floor(MAX_BYTES / (1024 * 1024));
 
   function showError(message) {
     errorEl.textContent = message;
@@ -21,7 +23,7 @@
       return;
     }
     if (file.size > MAX_BYTES) {
-      showError('Photos must be 10 MB or smaller.');
+      showError('Photos must be ' + MAX_MB + ' MB or smaller.');
       return;
     }
 

--- a/src/public/js/firearms-show.js
+++ b/src/public/js/firearms-show.js
@@ -76,3 +76,22 @@
     }
   });
 })();
+
+// Prefill log-form date inputs with the browser-local date. Done client-side
+// because the server clock (often UTC in Docker) can be a day off from the
+// user's timezone; without JS the fields stay blank and required.
+(function() {
+  const inputs = document.querySelectorAll('input[type="date"][data-default-today]');
+  if (!inputs.length) return;
+
+  const now = new Date();
+  const today = [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0')
+  ].join('-');
+
+  inputs.forEach((input) => {
+    if (!input.value) input.value = today;
+  });
+})();

--- a/src/shared/utils/dates.js
+++ b/src/shared/utils/dates.js
@@ -1,0 +1,17 @@
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+// Strict YYYY-MM-DD check with a real-calendar round trip, so values like
+// 2025-13-40 or 2025-02-30 are rejected. Log dates are compared as strings
+// (e.g. by the cleaning-due rule), which is only safe with this format.
+function isValidIsoDate(value) {
+  if (typeof value !== 'string' || !ISO_DATE_PATTERN.test(value)) {
+    return false;
+  }
+  const timestamp = Date.parse(`${value}T00:00:00Z`);
+  if (Number.isNaN(timestamp)) {
+    return false;
+  }
+  return new Date(timestamp).toISOString().slice(0, 10) === value;
+}
+
+module.exports = { isValidIsoDate };

--- a/src/views/auth/profile-content.ejs
+++ b/src/views/auth/profile-content.ejs
@@ -52,7 +52,7 @@
       <label>
         Cleaning reminder (days)
         <input type="number" name="maintenance_due_days" required min="1" max="365" step="1" value="<%= maintenanceDueDaysValue %>">
-        <span class="helper-text">Flag a firearm as due for cleaning this many days after its last cleaning log.</span>
+        <span class="helper-text">Flag a firearm as due for cleaning this many days after its last cleaning log, or as soon as it is fired after a cleaning.</span>
       </label>
       <% if (updateCheckAllowed) { %>
         <label class="toggle-row">

--- a/src/views/auth/profile-content.ejs
+++ b/src/views/auth/profile-content.ejs
@@ -49,6 +49,11 @@
           <option value="light" <%= themeValue === 'light' ? 'selected' : '' %>>Light</option>
         </select>
       </label>
+      <label>
+        Cleaning reminder (days)
+        <input type="number" name="maintenance_due_days" required min="1" max="365" step="1" value="<%= maintenanceDueDaysValue %>">
+        <span class="helper-text">Flag a firearm as due for cleaning this many days after its last cleaning log.</span>
+      </label>
       <% if (updateCheckAllowed) { %>
         <label class="toggle-row">
           <span class="toggle-label-text">

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -242,7 +242,7 @@
 
         <div class="photo-upload-row">
           <input type="file" accept="image/jpeg,image/png,image/webp,image/gif" aria-label="Choose a photo to upload" data-photo-input <%= photos.length >= maxPhotos ? 'disabled' : '' %>>
-          <button class="btn btn-primary" type="button" data-photo-upload data-photo-url="/firearms/<%= item.id %>/photos" <%= photos.length >= maxPhotos ? 'disabled' : '' %>>Upload</button>
+          <button class="btn btn-primary" type="button" data-photo-upload data-photo-url="/firearms/<%= item.id %>/photos" data-max-bytes="<%= maxPhotoBytes %>" <%= photos.length >= maxPhotos ? 'disabled' : '' %>>Upload</button>
         </div>
         <p class="field-error" data-photo-error hidden></p>
 

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -85,6 +85,84 @@
       <p class="section-header label-caps">Notes</p>
       <div class="notes"><%= item.notes || '-' %></div>
     </section>
+
+    <% if (typeof maintenance !== 'undefined' && maintenance) { %>
+      <section id="maintenance" class="detail-card detail-card-full panel log-section">
+        <div class="log-section-header">
+          <p class="section-header label-caps">Maintenance Log</p>
+          <% if (cleaningStatus && cleaningStatus.due) { %>
+            <span class="badge badge-repair">Cleaning due</span>
+          <% } %>
+        </div>
+        <% if (cleaningStatus && cleaningStatus.due && cleaningStatus.reason) { %>
+          <p class="meta log-due-reason"><%= cleaningStatus.reason %></p>
+        <% } %>
+
+        <details class="log-add">
+          <summary>Add entry</summary>
+          <form method="post" action="/firearms/<%= item.id %>/maintenance" class="form log-form">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <label>
+              Date
+              <input type="date" name="date" required value="<%= new Date().toISOString().slice(0, 10) %>">
+            </label>
+            <label>
+              Type
+              <select name="type" required>
+                <% maintenanceTypes.forEach((type) => { %>
+                  <option value="<%= type %>"><%= type %></option>
+                <% }) %>
+              </select>
+            </label>
+            <label>
+              Round count adjustment
+              <input type="number" name="round_count_delta" step="1" min="-100000" max="100000" placeholder="Optional">
+            </label>
+            <label>
+              Notes
+              <input type="text" name="notes" maxlength="2000" placeholder="Optional">
+            </label>
+            <div class="form-actions log-form-actions">
+              <button class="btn btn-primary" type="submit">Save entry</button>
+            </div>
+          </form>
+        </details>
+
+        <% if (!maintenance.length) { %>
+          <p class="muted-text meta">No maintenance logged yet.</p>
+        <% } else { %>
+          <div class="table-wrapper">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Type</th>
+                  <th>Rounds</th>
+                  <th>Notes</th>
+                  <th><span class="visually-hidden">Actions</span></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% maintenance.forEach((log) => { %>
+                  <tr>
+                    <td data-label="Date" class="mono"><%= log.date %></td>
+                    <td data-label="Type"><%= log.type %></td>
+                    <td data-label="Rounds" class="mono"><%= log.round_count_delta == null ? '-' : log.round_count_delta %></td>
+                    <td data-label="Notes"><%= log.notes || '-' %></td>
+                    <td data-label="Actions">
+                      <form method="post" action="/firearms/<%= item.id %>/maintenance/<%= log.id %>/delete" class="form-inline">
+                        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                        <button class="btn btn-danger" type="submit">Delete</button>
+                      </form>
+                    </td>
+                  </tr>
+                <% }) %>
+              </tbody>
+            </table>
+          </div>
+        <% } %>
+      </section>
+    <% } %>
   </div>
 
   <!-- Delete Confirmation Modal -->

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -232,6 +232,39 @@
         <% } %>
       </section>
     <% } %>
+
+    <% if (typeof photos !== 'undefined' && photos) { %>
+      <section id="photos" class="detail-card detail-card-full panel log-section">
+        <div class="log-section-header">
+          <p class="section-header label-caps">Photos</p>
+          <span class="meta"><%= photos.length %> / <%= maxPhotos %></span>
+        </div>
+
+        <div class="photo-upload-row">
+          <input type="file" accept="image/jpeg,image/png,image/webp,image/gif" data-photo-input <%= photos.length >= maxPhotos ? 'disabled' : '' %>>
+          <button class="btn btn-primary" type="button" data-photo-upload data-photo-url="/firearms/<%= item.id %>/photos" <%= photos.length >= maxPhotos ? 'disabled' : '' %>>Upload</button>
+        </div>
+        <p class="field-error" data-photo-error hidden></p>
+
+        <% if (!photos.length) { %>
+          <p class="muted-text meta">No photos yet.</p>
+        <% } else { %>
+          <div class="photo-grid">
+            <% photos.forEach((photo) => { %>
+              <div class="photo-item">
+                <a class="photo-thumb" href="/firearms/<%= item.id %>/photos/<%= photo.id %>" target="_blank" rel="noopener">
+                  <img src="/firearms/<%= item.id %>/photos/<%= photo.id %>" alt="<%= photo.original_name || 'Firearm photo' %>" loading="lazy">
+                </a>
+                <form method="post" action="/firearms/<%= item.id %>/photos/<%= photo.id %>/delete" class="photo-delete-form">
+                  <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                  <button class="btn btn-danger photo-delete" type="submit" aria-label="Delete photo">&times;</button>
+                </form>
+              </div>
+            <% }) %>
+          </div>
+        <% } %>
+      </section>
+    <% } %>
   </div>
 
   <!-- Delete Confirmation Modal -->

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -104,7 +104,7 @@
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <label>
               Date
-              <input type="date" name="date" required value="<%= new Date().toISOString().slice(0, 10) %>">
+              <input type="date" name="date" required data-default-today>
             </label>
             <label>
               Type
@@ -177,7 +177,7 @@
             <input type="hidden" name="_csrf" value="<%= csrfToken %>">
             <label>
               Date
-              <input type="date" name="date" required value="<%= new Date().toISOString().slice(0, 10) %>">
+              <input type="date" name="date" required data-default-today>
             </label>
             <label>
               Location
@@ -241,7 +241,7 @@
         </div>
 
         <div class="photo-upload-row">
-          <input type="file" accept="image/jpeg,image/png,image/webp,image/gif" data-photo-input <%= photos.length >= maxPhotos ? 'disabled' : '' %>>
+          <input type="file" accept="image/jpeg,image/png,image/webp,image/gif" aria-label="Choose a photo to upload" data-photo-input <%= photos.length >= maxPhotos ? 'disabled' : '' %>>
           <button class="btn btn-primary" type="button" data-photo-upload data-photo-url="/firearms/<%= item.id %>/photos" <%= photos.length >= maxPhotos ? 'disabled' : '' %>>Upload</button>
         </div>
         <p class="field-error" data-photo-error hidden></p>

--- a/src/views/firearms/show-content.ejs
+++ b/src/views/firearms/show-content.ejs
@@ -163,6 +163,75 @@
         <% } %>
       </section>
     <% } %>
+
+    <% if (typeof rangeSessions !== 'undefined' && rangeSessions) { %>
+      <section id="range-sessions" class="detail-card detail-card-full panel log-section">
+        <div class="log-section-header">
+          <p class="section-header label-caps">Range Sessions</p>
+          <span class="meta"><%= rangeTotals.session_count %> session<%= rangeTotals.session_count === 1 ? '' : 's' %> · <%= rangeTotals.total_rounds %> rounds</span>
+        </div>
+
+        <details class="log-add">
+          <summary>Add session</summary>
+          <form method="post" action="/firearms/<%= item.id %>/range-sessions" class="form log-form">
+            <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+            <label>
+              Date
+              <input type="date" name="date" required value="<%= new Date().toISOString().slice(0, 10) %>">
+            </label>
+            <label>
+              Location
+              <input type="text" name="location" maxlength="100" placeholder="Optional">
+            </label>
+            <label>
+              Rounds fired
+              <input type="number" name="rounds_fired" step="1" min="0" max="100000" placeholder="Optional">
+            </label>
+            <label>
+              Notes
+              <input type="text" name="notes" maxlength="2000" placeholder="Optional">
+            </label>
+            <div class="form-actions log-form-actions">
+              <button class="btn btn-primary" type="submit">Save session</button>
+            </div>
+          </form>
+        </details>
+
+        <% if (!rangeSessions.length) { %>
+          <p class="muted-text meta">No range sessions logged yet.</p>
+        <% } else { %>
+          <div class="table-wrapper">
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Date</th>
+                  <th>Location</th>
+                  <th>Rounds</th>
+                  <th>Notes</th>
+                  <th><span class="visually-hidden">Actions</span></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% rangeSessions.forEach((session) => { %>
+                  <tr>
+                    <td data-label="Date" class="mono"><%= session.date %></td>
+                    <td data-label="Location"><%= session.location || '-' %></td>
+                    <td data-label="Rounds" class="mono"><%= session.rounds_fired == null ? '-' : session.rounds_fired %></td>
+                    <td data-label="Notes"><%= session.notes || '-' %></td>
+                    <td data-label="Actions">
+                      <form method="post" action="/firearms/<%= item.id %>/range-sessions/<%= session.id %>/delete" class="form-inline">
+                        <input type="hidden" name="_csrf" value="<%= csrfToken %>">
+                        <button class="btn btn-danger" type="submit">Delete</button>
+                      </form>
+                    </td>
+                  </tr>
+                <% }) %>
+              </tbody>
+            </table>
+          </div>
+        <% } %>
+      </section>
+    <% } %>
   </div>
 
   <!-- Delete Confirmation Modal -->

--- a/src/views/firearms/show.ejs
+++ b/src/views/firearms/show.ejs
@@ -2,4 +2,4 @@
   const content = include('./show-content', locals);
   const title = item && (item.make || item.model) ? `${item.make || ''} ${item.model || ''}`.trim() : 'Firearm';
 %>
-<%- include('../partials/layout', { ...locals, body: content, pageTitle: title, pageScripts: ['/static/js/firearms-show.js', '/static/js/print-button.js'] }) %>
+<%- include('../partials/layout', { ...locals, body: content, pageTitle: title, pageScripts: ['/static/js/firearms-show.js', '/static/js/print-button.js', '/static/js/firearm-photos.js'] }) %>

--- a/src/views/home/index-content.ejs
+++ b/src/views/home/index-content.ejs
@@ -20,6 +20,10 @@
       <span class="home-stat-value home-stat-value-accent stat-value mono"><%= stats.lastUpdateDays %></span>
       <span class="home-stat-label stat-label label-caps">Last update</span>
     </div>
+    <div class="home-stat stat-card" role="listitem">
+      <span class="home-stat-value stat-value mono <%= stats.dueForCleaning > 0 ? 'home-stat-value-accent' : '' %>"><%= stats.dueForCleaning %></span>
+      <span class="home-stat-label stat-label label-caps">Due for cleaning</span>
+    </div>
   </div>
 </section>
 
@@ -49,6 +53,26 @@
     </div>
   </article>
 </section>
+
+<% if (typeof cleaningDue !== 'undefined' && cleaningDue && cleaningDue.length) { %>
+<section class="home-activity-section" aria-label="Cleaning due">
+  <article class="card home-card panel">
+    <header class="home-card-header">
+      <p class="label-caps">Maintenance</p>
+      <h3>Due for Cleaning</h3>
+    </header>
+    <div class="home-card-body">
+      <% cleaningDue.forEach((entry) => { %>
+        <div class="activity-row">
+          <span class="activity-dot is-recent" aria-hidden="true"></span>
+          <a class="activity-description" href="/firearms/<%= entry.id %>"><%= entry.label %></a>
+          <span class="activity-time meta"><%= entry.reason %></span>
+        </div>
+      <% }) %>
+    </div>
+  </article>
+</section>
+<% } %>
 
 <section class="home-chart-row" aria-label="Dashboard charts">
   <article class="card home-card panel">

--- a/tests/integration/maintenance.integration.test.js
+++ b/tests/integration/maintenance.integration.test.js
@@ -1,0 +1,292 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('supertest');
+
+const { createApp } = require('../../src/app/createApp');
+
+function testConfig(databasePath) {
+  return {
+    port: 0,
+    sessionSecret: 'test-secret',
+    adminUser: 'admin',
+    adminPass: 'password123',
+    databasePath
+  };
+}
+
+function extractCsrfToken(html) {
+  const match = html.match(/<input type="hidden" name="_csrf" value="([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+function isoDaysAgo(days) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+describe('maintenance routes', () => {
+  let app;
+  let dbPath;
+  let agent;
+
+  beforeEach(async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-maintenance-'));
+    dbPath = path.join(tempDir, 'app.db');
+    app = await createApp({ config: testConfig(dbPath) });
+    agent = request.agent(app);
+
+    const loginPage = await agent.get('/login');
+    const loginCsrfToken = extractCsrfToken(loginPage.text);
+
+    await agent
+      .post('/login')
+      .type('form')
+      .send({ username: 'admin', password: 'password123', _csrf: loginCsrfToken });
+
+    const changePasswordPage = await agent.get('/change-password');
+    const changeCsrfToken = extractCsrfToken(changePasswordPage.text);
+
+    await agent
+      .post('/change-password')
+      .type('form')
+      .send({
+        current_password: 'password123',
+        new_password: 'newSecurePassword123',
+        confirm_password: 'newSecurePassword123',
+        _csrf: changeCsrfToken
+      });
+  });
+
+  afterEach(() => {
+    app.locals.db.close();
+    const dir = path.dirname(dbPath);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function createFirearm(overrides = {}) {
+    const newPage = await agent.get('/firearms/new');
+    const csrfToken = extractCsrfToken(newPage.text);
+
+    const response = await agent
+      .post('/firearms')
+      .type('form')
+      .send({
+        make: 'Glock',
+        model: '19',
+        serial: '',
+        caliber: '9mm',
+        condition: 'New',
+        location: 'Safe',
+        status: 'Active',
+        firearm_type: 'Pistol',
+        _csrf: csrfToken,
+        ...overrides
+      });
+
+    expect(response.status).toBe(302);
+    return Number(response.headers.location.split('/').pop());
+  }
+
+  async function getCsrfTokenFromShowPage(firearmId) {
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.status).toBe(200);
+    return { token: extractCsrfToken(showPage.text), html: showPage.text };
+  }
+
+  test('detail page renders the maintenance section with an empty state', async () => {
+    const firearmId = await createFirearm();
+
+    const { html } = await getCsrfTokenFromShowPage(firearmId);
+
+    expect(html).toContain('Maintenance Log');
+    expect(html).toContain(`action="/firearms/${firearmId}/maintenance"`);
+    expect(html).toContain('No maintenance logged yet.');
+    expect(html).not.toContain('Cleaning due');
+  });
+
+  test('adds a maintenance entry and shows it on the detail page', async () => {
+    const firearmId = await createFirearm();
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    const response = await agent
+      .post(`/firearms/${firearmId}/maintenance`)
+      .type('form')
+      .send({
+        date: '2025-06-01',
+        type: 'Repair',
+        notes: 'Replaced trigger spring',
+        round_count_delta: '250',
+        _csrf: token
+      });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe(`/firearms/${firearmId}#maintenance`);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Maintenance entry added.');
+    expect(showPage.text).toContain('2025-06-01');
+    expect(showPage.text).toContain('Repair');
+    expect(showPage.text).toContain('Replaced trigger spring');
+    expect(showPage.text).toContain('250');
+  });
+
+  test('rejects an invalid date with an error flash', async () => {
+    const firearmId = await createFirearm();
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    const response = await agent
+      .post(`/firearms/${firearmId}/maintenance`)
+      .type('form')
+      .send({ date: '2025-13-40', type: 'Cleaning', _csrf: token });
+
+    expect(response.status).toBe(302);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Date must be a valid date in YYYY-MM-DD format.');
+    expect(showPage.text).toContain('No maintenance logged yet.');
+  });
+
+  test('deletes a maintenance entry', async () => {
+    const firearmId = await createFirearm();
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    await agent
+      .post(`/firearms/${firearmId}/maintenance`)
+      .type('form')
+      .send({ date: '2025-06-01', type: 'Cleaning', _csrf: token });
+
+    const logId = app.locals.db
+      .prepare('SELECT id FROM maintenance_logs WHERE firearm_id = ?')
+      .get(firearmId).id;
+
+    const { token: deleteToken } = await getCsrfTokenFromShowPage(firearmId);
+    const response = await agent
+      .post(`/firearms/${firearmId}/maintenance/${logId}/delete`)
+      .type('form')
+      .send({ _csrf: deleteToken });
+
+    expect(response.status).toBe(302);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Maintenance entry deleted.');
+    expect(showPage.text).toContain('No maintenance logged yet.');
+  });
+
+  test('returns 404 for a nonexistent firearm', async () => {
+    const firearmId = await createFirearm();
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    const response = await agent
+      .post('/firearms/9999/maintenance')
+      .type('form')
+      .send({ date: '2025-06-01', type: 'Cleaning', _csrf: token });
+
+    expect(response.status).toBe(404);
+  });
+
+  test('returns 404 when deleting a log that belongs to another firearm', async () => {
+    const firearmId = await createFirearm();
+    const otherFirearmId = await createFirearm({ make: 'Sig', model: 'P320' });
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    await agent
+      .post(`/firearms/${firearmId}/maintenance`)
+      .type('form')
+      .send({ date: '2025-06-01', type: 'Cleaning', _csrf: token });
+
+    const logId = app.locals.db
+      .prepare('SELECT id FROM maintenance_logs WHERE firearm_id = ?')
+      .get(firearmId).id;
+
+    const { token: deleteToken } = await getCsrfTokenFromShowPage(otherFirearmId);
+    const response = await agent
+      .post(`/firearms/${otherFirearmId}/maintenance/${logId}/delete`)
+      .type('form')
+      .send({ _csrf: deleteToken });
+
+    expect(response.status).toBe(404);
+    expect(app.locals.db.prepare('SELECT COUNT(*) AS count FROM maintenance_logs').get().count).toBe(1);
+  });
+
+  test('shows the cleaning-due badge and home dashboard stat for an overdue firearm', async () => {
+    const firearmId = await createFirearm();
+
+    app.locals.db
+      .prepare('INSERT INTO maintenance_logs (firearm_id, date, type) VALUES (?, ?, ?)')
+      .run(firearmId, isoDaysAgo(120), 'Cleaning');
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Cleaning due');
+    expect(showPage.text).toContain('Last cleaned 120 days ago');
+
+    const homePage = await agent.get('/');
+    expect(homePage.text).toContain('Due for cleaning');
+    expect(homePage.text).toContain('Due for Cleaning');
+    expect(homePage.text).toContain('Glock 19');
+  });
+
+  test('flags a firearm fired since its last cleaning', async () => {
+    const firearmId = await createFirearm();
+
+    app.locals.db
+      .prepare('INSERT INTO maintenance_logs (firearm_id, date, type) VALUES (?, ?, ?)')
+      .run(firearmId, isoDaysAgo(10), 'Cleaning');
+    app.locals.db
+      .prepare('INSERT INTO range_sessions (firearm_id, date, rounds_fired) VALUES (?, ?, ?)')
+      .run(firearmId, isoDaysAgo(2), 100);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Cleaning due');
+    expect(showPage.text).toContain('Range session since last cleaning');
+  });
+
+  test('honours the profile cleaning-reminder threshold', async () => {
+    const firearmId = await createFirearm();
+
+    app.locals.db
+      .prepare('INSERT INTO maintenance_logs (firearm_id, date, type) VALUES (?, ?, ?)')
+      .run(firearmId, isoDaysAgo(45), 'Cleaning');
+
+    let showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).not.toContain('Cleaning due');
+
+    const profilePage = await agent.get('/profile');
+    expect(profilePage.text).toContain('name="maintenance_due_days"');
+    const profileCsrfToken = extractCsrfToken(profilePage.text);
+
+    const preferencesResponse = await agent
+      .post('/profile/preferences')
+      .type('form')
+      .send({ theme: 'dark', maintenance_due_days: '30', _csrf: profileCsrfToken });
+
+    expect(preferencesResponse.status).toBe(200);
+    expect(preferencesResponse.text).toContain('Display preferences updated successfully');
+
+    showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Cleaning due');
+    expect(showPage.text).toContain('Last cleaned 45 days ago');
+  });
+
+  test('rejects an out-of-range cleaning-reminder threshold', async () => {
+    const profilePage = await agent.get('/profile');
+    const profileCsrfToken = extractCsrfToken(profilePage.text);
+
+    const response = await agent
+      .post('/profile/preferences')
+      .type('form')
+      .send({ theme: 'dark', maintenance_due_days: '0', _csrf: profileCsrfToken });
+
+    expect(response.status).toBe(400);
+    expect(response.text).toContain('Cleaning reminder must be a whole number of days between 1 and 365.');
+  });
+
+  test('requires authentication', async () => {
+    const response = await request(app).post('/firearms/1/maintenance').type('form').send({});
+
+    expect(response.status).toBe(403);
+
+    const getResponse = await request(app).get('/firearms/1');
+    expect(getResponse.status).toBe(302);
+    expect(getResponse.headers.location).toBe('/login');
+  });
+});

--- a/tests/integration/photos.integration.test.js
+++ b/tests/integration/photos.integration.test.js
@@ -1,0 +1,253 @@
+const crypto = require('crypto');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('supertest');
+
+const { createApp } = require('../../src/app/createApp');
+const { MAX_PHOTO_BYTES, MAX_PHOTOS_PER_FIREARM } = require('../../src/features/photos/photos.service');
+
+function testConfig(databasePath, photosDir) {
+  return {
+    port: 0,
+    sessionSecret: 'test-secret',
+    adminUser: 'admin',
+    adminPass: 'password123',
+    databasePath,
+    photosDir
+  };
+}
+
+function extractCsrfToken(html) {
+  const match = html.match(/<input type="hidden" name="_csrf" value="([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+describe('photos routes', () => {
+  let app;
+  let dbPath;
+  let photosDir;
+  let agent;
+
+  beforeEach(async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-photos-int-'));
+    dbPath = path.join(tempDir, 'app.db');
+    photosDir = path.join(tempDir, 'photos');
+    app = await createApp({ config: testConfig(dbPath, photosDir) });
+    agent = request.agent(app);
+
+    const loginPage = await agent.get('/login');
+    const loginCsrfToken = extractCsrfToken(loginPage.text);
+
+    await agent
+      .post('/login')
+      .type('form')
+      .send({ username: 'admin', password: 'password123', _csrf: loginCsrfToken });
+
+    const changePasswordPage = await agent.get('/change-password');
+    const changeCsrfToken = extractCsrfToken(changePasswordPage.text);
+
+    await agent
+      .post('/change-password')
+      .type('form')
+      .send({
+        current_password: 'password123',
+        new_password: 'newSecurePassword123',
+        confirm_password: 'newSecurePassword123',
+        _csrf: changeCsrfToken
+      });
+  });
+
+  afterEach(() => {
+    app.locals.db.close();
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  async function createFirearm(overrides = {}) {
+    const newPage = await agent.get('/firearms/new');
+    const csrfToken = extractCsrfToken(newPage.text);
+
+    const response = await agent
+      .post('/firearms')
+      .type('form')
+      .send({
+        make: 'Glock',
+        model: '19',
+        serial: '',
+        caliber: '9mm',
+        condition: 'New',
+        location: 'Safe',
+        status: 'Active',
+        firearm_type: 'Pistol',
+        _csrf: csrfToken,
+        ...overrides
+      });
+
+    expect(response.status).toBe(302);
+    return Number(response.headers.location.split('/').pop());
+  }
+
+  async function getCsrfToken(firearmId) {
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.status).toBe(200);
+    return extractCsrfToken(showPage.text);
+  }
+
+  function uploadPhoto(firearmId, token, { filename = 'pic.jpg', contentType = 'image/jpeg', buffer = Buffer.from('fake image bytes') } = {}) {
+    return agent
+      .post(`/firearms/${firearmId}/photos`)
+      .set('x-csrf-token', token)
+      .attach('photo', buffer, { filename, contentType });
+  }
+
+  test('uploads a photo, stores the file, and renders the gallery', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+
+    const response = await uploadPhoto(firearmId, token);
+
+    expect(response.status).toBe(201);
+    expect(response.body.id).toBeGreaterThan(0);
+
+    const files = fs.readdirSync(photosDir);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^[a-f0-9]{32}\.jpg$/);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain(`src="/firearms/${firearmId}/photos/${response.body.id}"`);
+    expect(showPage.text).toContain(`1 / ${MAX_PHOTOS_PER_FIREARM}`);
+  });
+
+  test('serves an uploaded photo with its content type', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+    const uploadResponse = await uploadPhoto(firearmId, token);
+
+    const response = await agent.get(`/firearms/${firearmId}/photos/${uploadResponse.body.id}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers['content-type']).toContain('image/jpeg');
+    expect(response.headers['cache-control']).toBe('private, max-age=86400');
+    expect(response.body.toString()).toBe('fake image bytes');
+  });
+
+  test('returns 404 when serving a photo through a different firearm', async () => {
+    const firearmId = await createFirearm();
+    const otherFirearmId = await createFirearm({ make: 'Sig', model: 'P320' });
+    const token = await getCsrfToken(firearmId);
+    const uploadResponse = await uploadPhoto(firearmId, token);
+
+    const response = await agent.get(`/firearms/${otherFirearmId}/photos/${uploadResponse.body.id}`);
+
+    expect(response.status).toBe(404);
+  });
+
+  test('returns 404 when uploading to a nonexistent firearm', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+
+    const response = await uploadPhoto(9999, token);
+
+    expect(response.status).toBe(404);
+  });
+
+  test('rejects an upload without the CSRF header', async () => {
+    const firearmId = await createFirearm();
+
+    const response = await agent
+      .post(`/firearms/${firearmId}/photos`)
+      .attach('photo', Buffer.from('fake image bytes'), { filename: 'pic.jpg', contentType: 'image/jpeg' });
+
+    expect(response.status).toBe(403);
+    expect(fs.readdirSync(photosDir)).toHaveLength(0);
+  });
+
+  test('rejects a disallowed file type', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+
+    const response = await uploadPhoto(firearmId, token, { filename: 'notes.txt', contentType: 'text/plain' });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Only JPEG, PNG, WebP, and GIF images are allowed.');
+    expect(fs.readdirSync(photosDir)).toHaveLength(0);
+  });
+
+  test('rejects an oversized upload', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+
+    const response = await uploadPhoto(firearmId, token, { buffer: Buffer.alloc(MAX_PHOTO_BYTES + 1) });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Photos must be 10 MB or smaller.');
+    expect(fs.readdirSync(photosDir)).toHaveLength(0);
+  });
+
+  test('rejects an upload past the per-firearm cap', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+
+    const insert = app.locals.db.prepare(
+      'INSERT INTO firearm_photos (firearm_id, filename, mime, size) VALUES (?, ?, ?, ?)'
+    );
+    for (let i = 0; i < MAX_PHOTOS_PER_FIREARM; i += 1) {
+      insert.run(firearmId, `${crypto.randomBytes(16).toString('hex')}.jpg`, 'image/jpeg', 10);
+    }
+
+    const response = await uploadPhoto(firearmId, token);
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe(`A firearm can have at most ${MAX_PHOTOS_PER_FIREARM} photos.`);
+  });
+
+  test('deletes a photo (row and file)', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+    const uploadResponse = await uploadPhoto(firearmId, token);
+
+    const deleteToken = await getCsrfToken(firearmId);
+    const response = await agent
+      .post(`/firearms/${firearmId}/photos/${uploadResponse.body.id}/delete`)
+      .type('form')
+      .send({ _csrf: deleteToken });
+
+    expect(response.status).toBe(302);
+    expect(fs.readdirSync(photosDir)).toHaveLength(0);
+    expect(app.locals.db.prepare('SELECT COUNT(*) AS count FROM firearm_photos').get().count).toBe(0);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Photo deleted.');
+    expect(showPage.text).toContain('No photos yet.');
+  });
+
+  test('deleting a firearm removes its photo files from disk', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+    await uploadPhoto(firearmId, token);
+    await uploadPhoto(firearmId, token, { filename: 'second.png', contentType: 'image/png' });
+
+    expect(fs.readdirSync(photosDir)).toHaveLength(2);
+
+    const deleteToken = await getCsrfToken(firearmId);
+    const response = await agent
+      .post(`/firearms/${firearmId}/delete`)
+      .type('form')
+      .send({ _csrf: deleteToken });
+
+    expect(response.status).toBe(302);
+    expect(fs.readdirSync(photosDir)).toHaveLength(0);
+    expect(app.locals.db.prepare('SELECT COUNT(*) AS count FROM firearm_photos').get().count).toBe(0);
+  });
+
+  test('requires authentication to view a photo', async () => {
+    const firearmId = await createFirearm();
+    const token = await getCsrfToken(firearmId);
+    const uploadResponse = await uploadPhoto(firearmId, token);
+
+    const response = await request(app).get(`/firearms/${firearmId}/photos/${uploadResponse.body.id}`);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe('/login');
+  });
+});

--- a/tests/integration/range-sessions.integration.test.js
+++ b/tests/integration/range-sessions.integration.test.js
@@ -1,0 +1,211 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const request = require('supertest');
+
+const { createApp } = require('../../src/app/createApp');
+
+function testConfig(databasePath) {
+  return {
+    port: 0,
+    sessionSecret: 'test-secret',
+    adminUser: 'admin',
+    adminPass: 'password123',
+    databasePath
+  };
+}
+
+function extractCsrfToken(html) {
+  const match = html.match(/<input type="hidden" name="_csrf" value="([^"]+)"/);
+  return match ? match[1] : null;
+}
+
+describe('range sessions routes', () => {
+  let app;
+  let dbPath;
+  let agent;
+
+  beforeEach(async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-range-sessions-'));
+    dbPath = path.join(tempDir, 'app.db');
+    app = await createApp({ config: testConfig(dbPath) });
+    agent = request.agent(app);
+
+    const loginPage = await agent.get('/login');
+    const loginCsrfToken = extractCsrfToken(loginPage.text);
+
+    await agent
+      .post('/login')
+      .type('form')
+      .send({ username: 'admin', password: 'password123', _csrf: loginCsrfToken });
+
+    const changePasswordPage = await agent.get('/change-password');
+    const changeCsrfToken = extractCsrfToken(changePasswordPage.text);
+
+    await agent
+      .post('/change-password')
+      .type('form')
+      .send({
+        current_password: 'password123',
+        new_password: 'newSecurePassword123',
+        confirm_password: 'newSecurePassword123',
+        _csrf: changeCsrfToken
+      });
+  });
+
+  afterEach(() => {
+    app.locals.db.close();
+    const dir = path.dirname(dbPath);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function createFirearm(overrides = {}) {
+    const newPage = await agent.get('/firearms/new');
+    const csrfToken = extractCsrfToken(newPage.text);
+
+    const response = await agent
+      .post('/firearms')
+      .type('form')
+      .send({
+        make: 'Glock',
+        model: '19',
+        serial: '',
+        caliber: '9mm',
+        condition: 'New',
+        location: 'Safe',
+        status: 'Active',
+        firearm_type: 'Pistol',
+        _csrf: csrfToken,
+        ...overrides
+      });
+
+    expect(response.status).toBe(302);
+    return Number(response.headers.location.split('/').pop());
+  }
+
+  async function getCsrfTokenFromShowPage(firearmId) {
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.status).toBe(200);
+    return { token: extractCsrfToken(showPage.text), html: showPage.text };
+  }
+
+  test('detail page renders the range sessions section with an empty state', async () => {
+    const firearmId = await createFirearm();
+
+    const { html } = await getCsrfTokenFromShowPage(firearmId);
+
+    expect(html).toContain('Range Sessions');
+    expect(html).toContain(`action="/firearms/${firearmId}/range-sessions"`);
+    expect(html).toContain('No range sessions logged yet.');
+    expect(html).toContain('0 sessions · 0 rounds');
+  });
+
+  test('adds a range session and shows it with updated totals', async () => {
+    const firearmId = await createFirearm();
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    const response = await agent
+      .post(`/firearms/${firearmId}/range-sessions`)
+      .type('form')
+      .send({
+        date: '2025-06-01',
+        location: 'Indoor Range',
+        rounds_fired: '150',
+        notes: 'Zeroed the red dot',
+        _csrf: token
+      });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.location).toBe(`/firearms/${firearmId}#range-sessions`);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Range session added.');
+    expect(showPage.text).toContain('Indoor Range');
+    expect(showPage.text).toContain('Zeroed the red dot');
+    expect(showPage.text).toContain('1 session · 150 rounds');
+  });
+
+  test('rejects invalid input with an error flash', async () => {
+    const firearmId = await createFirearm();
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    const response = await agent
+      .post(`/firearms/${firearmId}/range-sessions`)
+      .type('form')
+      .send({ date: '2025-06-01', rounds_fired: '-5', _csrf: token });
+
+    expect(response.status).toBe(302);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Rounds fired cannot be negative.');
+    expect(showPage.text).toContain('No range sessions logged yet.');
+  });
+
+  test('deletes a range session', async () => {
+    const firearmId = await createFirearm();
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    await agent
+      .post(`/firearms/${firearmId}/range-sessions`)
+      .type('form')
+      .send({ date: '2025-06-01', rounds_fired: '50', _csrf: token });
+
+    const sessionId = app.locals.db
+      .prepare('SELECT id FROM range_sessions WHERE firearm_id = ?')
+      .get(firearmId).id;
+
+    const { token: deleteToken } = await getCsrfTokenFromShowPage(firearmId);
+    const response = await agent
+      .post(`/firearms/${firearmId}/range-sessions/${sessionId}/delete`)
+      .type('form')
+      .send({ _csrf: deleteToken });
+
+    expect(response.status).toBe(302);
+
+    const showPage = await agent.get(`/firearms/${firearmId}`);
+    expect(showPage.text).toContain('Range session deleted.');
+    expect(showPage.text).toContain('No range sessions logged yet.');
+  });
+
+  test('returns 404 for a nonexistent firearm', async () => {
+    const firearmId = await createFirearm();
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    const response = await agent
+      .post('/firearms/9999/range-sessions')
+      .type('form')
+      .send({ date: '2025-06-01', _csrf: token });
+
+    expect(response.status).toBe(404);
+  });
+
+  test('returns 404 when deleting a session that belongs to another firearm', async () => {
+    const firearmId = await createFirearm();
+    const otherFirearmId = await createFirearm({ make: 'Sig', model: 'P320' });
+    const { token } = await getCsrfTokenFromShowPage(firearmId);
+
+    await agent
+      .post(`/firearms/${firearmId}/range-sessions`)
+      .type('form')
+      .send({ date: '2025-06-01', _csrf: token });
+
+    const sessionId = app.locals.db
+      .prepare('SELECT id FROM range_sessions WHERE firearm_id = ?')
+      .get(firearmId).id;
+
+    const { token: deleteToken } = await getCsrfTokenFromShowPage(otherFirearmId);
+    const response = await agent
+      .post(`/firearms/${otherFirearmId}/range-sessions/${sessionId}/delete`)
+      .type('form')
+      .send({ _csrf: deleteToken });
+
+    expect(response.status).toBe(404);
+    expect(app.locals.db.prepare('SELECT COUNT(*) AS count FROM range_sessions').get().count).toBe(1);
+  });
+
+  test('requires authentication', async () => {
+    const response = await request(app).post('/firearms/1/range-sessions').type('form').send({});
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/tests/unit/auth.service.test.js
+++ b/tests/unit/auth.service.test.js
@@ -80,4 +80,25 @@ describe('auth service', () => {
       expect(theme).toBe('light');
     });
   });
+
+  describe('maintenance due days', () => {
+    test('getMaintenanceDueDays returns the default when unset', () => {
+      expect(authService.getMaintenanceDueDays()).toBe(90);
+    });
+
+    test('setMaintenanceDueDays persists a valid value', () => {
+      authService.setMaintenanceDueDays('30');
+      expect(authService.getMaintenanceDueDays()).toBe(30);
+    });
+
+    test.each(['0', '366', '-1', 'abc', '', '30.5'])(
+      'setMaintenanceDueDays rejects %s',
+      (value) => {
+        expect(() => authService.setMaintenanceDueDays(value)).toThrow(
+          'Cleaning reminder must be a whole number of days between 1 and 365.'
+        );
+        expect(authService.getMaintenanceDueDays()).toBe(90);
+      }
+    );
+  });
 });

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -113,6 +113,29 @@ describe('getConfig', () => {
     });
   });
 
+  describe('data and photos directories', () => {
+    afterEach(() => {
+      delete process.env.DATA_DIR;
+    });
+
+    test('derives dataDir and photosDir from the default data directory', () => {
+      const path = require('path');
+      const config = getConfig();
+      expect(config.dataDir).toBe(path.join(process.cwd(), 'data'));
+      expect(config.photosDir).toBe(path.join(process.cwd(), 'data', 'photos'));
+    });
+
+    test('derives dataDir and photosDir from DATA_DIR when set', () => {
+      const path = require('path');
+      process.env.DATA_DIR = '/data';
+      process.env.DATABASE_PATH = '/data/app.db';
+      const config = getConfig();
+      delete process.env.DATABASE_PATH;
+      expect(config.dataDir).toBe(path.resolve('/data'));
+      expect(config.photosDir).toBe(path.resolve('/data/photos'));
+    });
+  });
+
   describe('SESSION_SECRET guard', () => {
     test('uses provided SESSION_SECRET', () => {
       process.env.SESSION_SECRET = 'my-strong-secret';

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -106,6 +106,13 @@ describe('getConfig', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
+    test('defaults the database file inside DATA_DIR when only DATA_DIR is set', () => {
+      const path = require('path');
+      process.env.DATA_DIR = '/data';
+      const config = getConfig();
+      expect(config.databasePath).toBe(path.resolve('/data/app.db'));
+    });
+
     test('accepts the bundled Docker defaults (DATA_DIR=/data, DATABASE_PATH=/data/app.db)', () => {
       process.env.DATA_DIR = '/data';
       process.env.DATABASE_PATH = '/data/app.db';
@@ -128,9 +135,7 @@ describe('getConfig', () => {
     test('derives dataDir and photosDir from DATA_DIR when set', () => {
       const path = require('path');
       process.env.DATA_DIR = '/data';
-      process.env.DATABASE_PATH = '/data/app.db';
       const config = getConfig();
-      delete process.env.DATABASE_PATH;
       expect(config.dataDir).toBe(path.resolve('/data'));
       expect(config.photosDir).toBe(path.resolve('/data/photos'));
     });

--- a/tests/unit/home.service.test.js
+++ b/tests/unit/home.service.test.js
@@ -45,8 +45,10 @@ describe('home service', () => {
       totalFirearms: 24,
       thisMonth: 3,
       categories: 6,
-      lastUpdateDays: '2d'
+      lastUpdateDays: '2d',
+      dueForCleaning: 0
     });
+    expect(result.cleaningDue).toEqual([]);
 
     expect(result.charts).toEqual({
       typeBreakdown: [{ firearm_type: 'Pistol', count: 10 }],
@@ -60,5 +62,33 @@ describe('home service', () => {
     expect(firearmsRepository.getRecentActivity).toHaveBeenCalledWith(5);
     expect(firearmsRepository.getTypeBreakdown).toHaveBeenCalledTimes(1);
     expect(firearmsRepository.getValueByYear).toHaveBeenCalledTimes(1);
+  });
+
+  test('includes cleaning-due data from the maintenance service when provided', () => {
+    const firearmsRepository = {
+      getCollectionSummary: jest.fn(() => ({})),
+      getRecentActivity: jest.fn(() => []),
+      getTypeBreakdown: jest.fn(() => []),
+      getValueByYear: jest.fn(() => [])
+    };
+
+    const dueItems = Array.from({ length: 7 }, (_, index) => ({
+      id: index + 1,
+      label: `Firearm ${index + 1}`,
+      reason: 'Last cleaned 100 days ago',
+      daysSince: 100
+    }));
+
+    const maintenanceService = {
+      getDueForCleaning: jest.fn(() => ({ count: dueItems.length, items: dueItems, thresholdDays: 90 }))
+    };
+
+    const service = createHomeService(firearmsRepository, maintenanceService);
+    const result = service.getDashboard('admin', 3);
+
+    expect(maintenanceService.getDueForCleaning).toHaveBeenCalledWith(3);
+    expect(result.stats.dueForCleaning).toBe(7);
+    expect(result.cleaningDue).toHaveLength(5);
+    expect(result.cleaningDue[0].label).toBe('Firearm 1');
   });
 });

--- a/tests/unit/maintenance.repository.test.js
+++ b/tests/unit/maintenance.repository.test.js
@@ -44,11 +44,11 @@ describe('maintenance repository', () => {
     fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
   });
 
-  function insertRangeSession(targetFirearmId, date) {
+  function insertRangeSession(targetFirearmId, date, roundsFired = 50) {
     db.prepare('INSERT INTO range_sessions (firearm_id, date, rounds_fired) VALUES (?, ?, ?)').run(
       targetFirearmId,
       date,
-      50
+      roundsFired
     );
   }
 
@@ -116,6 +116,17 @@ describe('maintenance repository', () => {
 
     const rows = maintenanceRepo.getCleaningStatus(1);
     expect(rows[0].last_range).toBe('2025-04-20');
+  });
+
+  test('getCleaningStatus ignores zero-round sessions but counts unknown-round sessions', () => {
+    insertRangeSession(firearmId, '2025-03-15', 50);
+    insertRangeSession(firearmId, '2025-04-20', 0);
+
+    expect(maintenanceRepo.getCleaningStatus(1)[0].last_range).toBe('2025-03-15');
+    expect(maintenanceRepo.getFirearmCleaningDates(firearmId).last_range).toBe('2025-03-15');
+
+    insertRangeSession(firearmId, '2025-05-01', null);
+    expect(maintenanceRepo.getCleaningStatus(1)[0].last_range).toBe('2025-05-01');
   });
 
   test('getCleaningStatus only includes firearms for the given user', () => {

--- a/tests/unit/maintenance.repository.test.js
+++ b/tests/unit/maintenance.repository.test.js
@@ -1,0 +1,148 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createDbClient } = require('../../src/infra/db/client');
+const { migrate } = require('../../src/infra/db/migrate');
+const { createFirearmsRepository } = require('../../src/infra/db/repositories/firearms.repository');
+const { createMaintenanceRepository } = require('../../src/infra/db/repositories/maintenance.repository');
+
+const MINIMAL_FIREARM = {
+  make: 'Glock',
+  model: '19',
+  serial: '',
+  caliber: '9mm',
+  purchase_date: '2024-01-01',
+  purchase_price: 500,
+  condition: 'New',
+  location: 'Safe',
+  status: 'Active',
+  notes: '',
+  gun_warranty: 0,
+  firearm_type: 'Pistol'
+};
+
+describe('maintenance repository', () => {
+  let db;
+  let dbPath;
+  let firearmsRepo;
+  let maintenanceRepo;
+  let firearmId;
+
+  beforeEach(() => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-maint-'));
+    dbPath = path.join(tempDir, 'app.db');
+    db = createDbClient(dbPath);
+    migrate(db);
+    firearmsRepo = createFirearmsRepository(db);
+    maintenanceRepo = createMaintenanceRepository(db);
+    firearmId = firearmsRepo.create({ ...MINIMAL_FIREARM });
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  function insertRangeSession(targetFirearmId, date) {
+    db.prepare('INSERT INTO range_sessions (firearm_id, date, rounds_fired) VALUES (?, ?, ?)').run(
+      targetFirearmId,
+      date,
+      50
+    );
+  }
+
+  test('create returns the new id and listByFirearm orders by date descending', () => {
+    const older = maintenanceRepo.create({ firearm_id: firearmId, date: '2025-01-01', type: 'Cleaning' });
+    const newer = maintenanceRepo.create({ firearm_id: firearmId, date: '2025-06-01', type: 'Repair', notes: 'Barrel' });
+
+    expect(older).toBeGreaterThan(0);
+    expect(newer).toBeGreaterThan(older);
+
+    const rows = maintenanceRepo.listByFirearm(firearmId);
+    expect(rows.map((r) => r.date)).toEqual(['2025-06-01', '2025-01-01']);
+    expect(rows[0].notes).toBe('Barrel');
+    expect(rows[1].round_count_delta).toBeNull();
+  });
+
+  test('same-date entries order newest-inserted first', () => {
+    const first = maintenanceRepo.create({ firearm_id: firearmId, date: '2025-03-01', type: 'Cleaning' });
+    const second = maintenanceRepo.create({ firearm_id: firearmId, date: '2025-03-01', type: 'Inspection' });
+
+    const rows = maintenanceRepo.listByFirearm(firearmId);
+    expect(rows.map((r) => r.id)).toEqual([second, first]);
+  });
+
+  test('get and remove are scoped to the firearm', () => {
+    const otherFirearmId = firearmsRepo.create({ ...MINIMAL_FIREARM, make: 'Sig', model: 'P320' });
+    const logId = maintenanceRepo.create({ firearm_id: firearmId, date: '2025-02-02', type: 'Cleaning' });
+
+    expect(maintenanceRepo.get(logId, firearmId)).toBeTruthy();
+    expect(maintenanceRepo.get(logId, otherFirearmId)).toBeUndefined();
+
+    maintenanceRepo.remove(logId, otherFirearmId);
+    expect(maintenanceRepo.get(logId, firearmId)).toBeTruthy();
+
+    maintenanceRepo.remove(logId, firearmId);
+    expect(maintenanceRepo.get(logId, firearmId)).toBeUndefined();
+  });
+
+  test('getCleaningStatus reports null dates when nothing is logged', () => {
+    const rows = maintenanceRepo.getCleaningStatus(1);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      id: firearmId,
+      make: 'Glock',
+      model: '19',
+      status: 'Active',
+      last_cleaned: null,
+      last_range: null
+    });
+  });
+
+  test('getCleaningStatus picks the latest Cleaning log and ignores other types', () => {
+    maintenanceRepo.create({ firearm_id: firearmId, date: '2025-01-05', type: 'Cleaning' });
+    maintenanceRepo.create({ firearm_id: firearmId, date: '2025-02-10', type: 'Cleaning' });
+    maintenanceRepo.create({ firearm_id: firearmId, date: '2025-05-01', type: 'Repair' });
+
+    const rows = maintenanceRepo.getCleaningStatus(1);
+    expect(rows[0].last_cleaned).toBe('2025-02-10');
+  });
+
+  test('getCleaningStatus surfaces the latest range session date', () => {
+    insertRangeSession(firearmId, '2025-03-15');
+    insertRangeSession(firearmId, '2025-04-20');
+
+    const rows = maintenanceRepo.getCleaningStatus(1);
+    expect(rows[0].last_range).toBe('2025-04-20');
+  });
+
+  test('getCleaningStatus only includes firearms for the given user', () => {
+    firearmsRepo.create({ ...MINIMAL_FIREARM, make: 'CZ', model: '75', user_id: 2 });
+
+    const userOneRows = maintenanceRepo.getCleaningStatus(1);
+    const userTwoRows = maintenanceRepo.getCleaningStatus(2);
+
+    expect(userOneRows.map((r) => r.make)).toEqual(['Glock']);
+    expect(userTwoRows.map((r) => r.make)).toEqual(['CZ']);
+  });
+
+  test('getFirearmCleaningDates returns both dates for one firearm', () => {
+    maintenanceRepo.create({ firearm_id: firearmId, date: '2025-01-01', type: 'Cleaning' });
+    insertRangeSession(firearmId, '2025-02-01');
+
+    expect(maintenanceRepo.getFirearmCleaningDates(firearmId)).toEqual({
+      last_cleaned: '2025-01-01',
+      last_range: '2025-02-01'
+    });
+  });
+
+  test('deleting a firearm cascades to its maintenance logs', () => {
+    const logId = maintenanceRepo.create({ firearm_id: firearmId, date: '2025-01-01', type: 'Cleaning' });
+
+    firearmsRepo.remove(firearmId, 1);
+
+    expect(maintenanceRepo.get(logId, firearmId)).toBeUndefined();
+  });
+});

--- a/tests/unit/maintenance.service.test.js
+++ b/tests/unit/maintenance.service.test.js
@@ -1,0 +1,212 @@
+const {
+  createMaintenanceService,
+  parseMaintenanceDueDays,
+  DEFAULT_CLEANING_DUE_DAYS
+} = require('../../src/features/maintenance/maintenance.service');
+
+function isoDaysAgo(days) {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+}
+
+function buildService({ statusRows = [], firearmDates = null, dueDaysSetting = null } = {}) {
+  const maintenanceRepository = {
+    listByFirearm: jest.fn(() => []),
+    get: jest.fn(),
+    create: jest.fn(() => 42),
+    remove: jest.fn(),
+    getCleaningStatus: jest.fn(() => statusRows),
+    getFirearmCleaningDates: jest.fn(() => firearmDates)
+  };
+  const settingsRepository = {
+    get: jest.fn(() => dueDaysSetting)
+  };
+  return {
+    service: createMaintenanceService(maintenanceRepository, settingsRepository),
+    maintenanceRepository,
+    settingsRepository
+  };
+}
+
+describe('parseMaintenanceDueDays', () => {
+  test('returns the parsed value when in range', () => {
+    expect(parseMaintenanceDueDays('30')).toBe(30);
+    expect(parseMaintenanceDueDays('365')).toBe(365);
+    expect(parseMaintenanceDueDays('1')).toBe(1);
+  });
+
+  test.each([null, undefined, '', '0', '366', '-5', 'abc', '30.5'])(
+    'falls back to the default for %s',
+    (raw) => {
+      expect(parseMaintenanceDueDays(raw)).toBe(DEFAULT_CLEANING_DUE_DAYS);
+    }
+  );
+});
+
+describe('maintenance service CRUD passthrough', () => {
+  test('create attaches the firearm id and returns the new row id', () => {
+    const { service, maintenanceRepository } = buildService();
+
+    const id = service.create(7, { date: '2025-01-01', type: 'Cleaning', notes: '', round_count_delta: null });
+
+    expect(id).toBe(42);
+    expect(maintenanceRepository.create).toHaveBeenCalledWith({
+      firearm_id: 7,
+      date: '2025-01-01',
+      type: 'Cleaning',
+      notes: '',
+      round_count_delta: null
+    });
+  });
+
+  test('listByFirearm, get, and remove delegate to the repository', () => {
+    const { service, maintenanceRepository } = buildService();
+
+    service.listByFirearm(7);
+    service.get(3, 7);
+    service.remove(3, 7);
+
+    expect(maintenanceRepository.listByFirearm).toHaveBeenCalledWith(7);
+    expect(maintenanceRepository.get).toHaveBeenCalledWith(3, 7);
+    expect(maintenanceRepository.remove).toHaveBeenCalledWith(3, 7);
+  });
+});
+
+describe('getDueForCleaning', () => {
+  function row(overrides = {}) {
+    return {
+      id: 1,
+      make: 'Glock',
+      model: '19',
+      status: 'Active',
+      last_cleaned: null,
+      last_range: null,
+      ...overrides
+    };
+  }
+
+  test('flags a firearm cleaned past the default threshold', () => {
+    const { service } = buildService({
+      statusRows: [row({ last_cleaned: isoDaysAgo(91) })]
+    });
+
+    const result = service.getDueForCleaning(1);
+
+    expect(result.count).toBe(1);
+    expect(result.thresholdDays).toBe(DEFAULT_CLEANING_DUE_DAYS);
+    expect(result.items[0]).toMatchObject({ id: 1, label: 'Glock 19', daysSince: 91 });
+    expect(result.items[0].reason).toBe('Last cleaned 91 days ago');
+  });
+
+  test('does not flag a firearm cleaned within the threshold', () => {
+    const { service } = buildService({
+      statusRows: [row({ last_cleaned: isoDaysAgo(89) })]
+    });
+
+    expect(service.getDueForCleaning(1).count).toBe(0);
+  });
+
+  test('honours a custom threshold from settings', () => {
+    const { service, settingsRepository } = buildService({
+      statusRows: [row({ last_cleaned: isoDaysAgo(31) })],
+      dueDaysSetting: '30'
+    });
+
+    const result = service.getDueForCleaning(1);
+
+    expect(settingsRepository.get).toHaveBeenCalledWith('maintenance_due_days');
+    expect(result.thresholdDays).toBe(30);
+    expect(result.count).toBe(1);
+  });
+
+  test('flags a range session newer than the last cleaning', () => {
+    const { service } = buildService({
+      statusRows: [row({ last_cleaned: isoDaysAgo(10), last_range: isoDaysAgo(5) })]
+    });
+
+    const result = service.getDueForCleaning(1);
+
+    expect(result.count).toBe(1);
+    expect(result.items[0].reason).toBe('Range session since last cleaning');
+  });
+
+  test('flags a firearm that was fired but never cleaned', () => {
+    const { service } = buildService({
+      statusRows: [row({ last_range: isoDaysAgo(2) })]
+    });
+
+    const result = service.getDueForCleaning(1);
+
+    expect(result.count).toBe(1);
+    expect(result.items[0].daysSince).toBeNull();
+  });
+
+  test('does not flag when the last cleaning is newer than the last range session', () => {
+    const { service } = buildService({
+      statusRows: [row({ last_cleaned: isoDaysAgo(3), last_range: isoDaysAgo(5) })]
+    });
+
+    expect(service.getDueForCleaning(1).count).toBe(0);
+  });
+
+  test('skips disposed firearms and firearms with no activity', () => {
+    const { service } = buildService({
+      statusRows: [
+        row({ id: 1, status: 'Sold', last_cleaned: isoDaysAgo(400) }),
+        row({ id: 2, status: 'Lost/Stolen', last_range: isoDaysAgo(1) }),
+        row({ id: 3 })
+      ]
+    });
+
+    expect(service.getDueForCleaning(1).count).toBe(0);
+  });
+
+  test('passes the user id through to the repository', () => {
+    const { service, maintenanceRepository } = buildService();
+
+    service.getDueForCleaning(5);
+
+    expect(maintenanceRepository.getCleaningStatus).toHaveBeenCalledWith(5);
+  });
+});
+
+describe('getCleaningStatusForFirearm', () => {
+  test('reports due with a reason for an overdue cleaning', () => {
+    const lastCleaned = isoDaysAgo(120);
+    const { service } = buildService({ firearmDates: { last_cleaned: lastCleaned, last_range: null } });
+
+    const result = service.getCleaningStatusForFirearm(7, 'Active');
+
+    expect(result.due).toBe(true);
+    expect(result.reason).toBe('Last cleaned 120 days ago');
+    expect(result.lastCleaned).toBe(lastCleaned);
+  });
+
+  test('reports not due for a recently cleaned firearm', () => {
+    const { service } = buildService({
+      firearmDates: { last_cleaned: isoDaysAgo(5), last_range: isoDaysAgo(30) }
+    });
+
+    const result = service.getCleaningStatusForFirearm(7, 'Active');
+
+    expect(result.due).toBe(false);
+    expect(result.reason).toBeNull();
+  });
+
+  test('never reports due for a disposed firearm', () => {
+    const { service, maintenanceRepository } = buildService();
+
+    const result = service.getCleaningStatusForFirearm(7, 'Sold');
+
+    expect(result.due).toBe(false);
+    expect(maintenanceRepository.getFirearmCleaningDates).not.toHaveBeenCalled();
+  });
+
+  test('tolerates a missing dates row', () => {
+    const { service } = buildService({ firearmDates: undefined });
+
+    const result = service.getCleaningStatusForFirearm(7, 'Active');
+
+    expect(result.due).toBe(false);
+    expect(result.lastCleaned).toBeNull();
+  });
+});

--- a/tests/unit/maintenance.service.test.js
+++ b/tests/unit/maintenance.service.test.js
@@ -167,6 +167,20 @@ describe('getDueForCleaning', () => {
 
     expect(maintenanceRepository.getCleaningStatus).toHaveBeenCalledWith(5);
   });
+
+  test('orders items most-urgent first: never-cleaned-but-fired, then longest since cleaning', () => {
+    const { service } = buildService({
+      statusRows: [
+        row({ id: 1, make: 'Beretta', model: '92', last_cleaned: isoDaysAgo(120) }),
+        row({ id: 2, make: 'Colt', model: '1911', last_range: isoDaysAgo(2) }),
+        row({ id: 3, make: 'Anschutz', model: '54', last_cleaned: isoDaysAgo(300) })
+      ]
+    });
+
+    const result = service.getDueForCleaning(1);
+
+    expect(result.items.map((item) => item.id)).toEqual([2, 3, 1]);
+  });
 });
 
 describe('getCleaningStatusForFirearm', () => {

--- a/tests/unit/maintenance.validators.test.js
+++ b/tests/unit/maintenance.validators.test.js
@@ -1,0 +1,91 @@
+const {
+  sanitizeMaintenanceInput,
+  validateMaintenanceInput,
+  MAINTENANCE_TYPES,
+  NOTES_MAX_LENGTH,
+  MAX_ROUND_COUNT_DELTA
+} = require('../../src/features/maintenance/maintenance.validators');
+
+describe('sanitizeMaintenanceInput', () => {
+  test('trims strings and converts an empty delta to null', () => {
+    const result = sanitizeMaintenanceInput({
+      date: ' 2025-06-01 ',
+      type: ' Cleaning ',
+      notes: ' Wiped down ',
+      round_count_delta: ''
+    });
+
+    expect(result).toEqual({
+      date: '2025-06-01',
+      type: 'Cleaning',
+      notes: 'Wiped down',
+      round_count_delta: null
+    });
+  });
+
+  test('converts a numeric delta string to a number', () => {
+    expect(sanitizeMaintenanceInput({ round_count_delta: '150' }).round_count_delta).toBe(150);
+    expect(sanitizeMaintenanceInput({ round_count_delta: '-25' }).round_count_delta).toBe(-25);
+  });
+
+  test('defaults missing fields to empty values', () => {
+    expect(sanitizeMaintenanceInput({})).toEqual({
+      date: '',
+      type: '',
+      notes: '',
+      round_count_delta: null
+    });
+  });
+});
+
+describe('validateMaintenanceInput', () => {
+  const VALID = { date: '2025-06-01', type: 'Cleaning', notes: '', round_count_delta: null };
+
+  test('accepts a valid entry', () => {
+    expect(validateMaintenanceInput(VALID)).toEqual({ isValid: true, fieldErrors: {} });
+  });
+
+  test('accepts every listed maintenance type', () => {
+    for (const type of MAINTENANCE_TYPES) {
+      expect(validateMaintenanceInput({ ...VALID, type }).isValid).toBe(true);
+    }
+  });
+
+  test('requires a date', () => {
+    const result = validateMaintenanceInput({ ...VALID, date: '' });
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.date).toBe('Date is required.');
+  });
+
+  test.each(['2025-13-40', '2025-02-30', '01/02/2025', '2025-6-1', 'not-a-date'])(
+    'rejects malformed date %s',
+    (date) => {
+      const result = validateMaintenanceInput({ ...VALID, date });
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.date).toBe('Date must be a valid date in YYYY-MM-DD format.');
+    }
+  );
+
+  test('requires a known type', () => {
+    expect(validateMaintenanceInput({ ...VALID, type: '' }).fieldErrors.type).toBe('Type is required.');
+    expect(validateMaintenanceInput({ ...VALID, type: 'Polishing' }).fieldErrors.type).toBe(
+      'Type must be one of the listed maintenance types.'
+    );
+  });
+
+  test('rejects notes over the limit', () => {
+    const result = validateMaintenanceInput({ ...VALID, notes: 'x'.repeat(NOTES_MAX_LENGTH + 1) });
+    expect(result.fieldErrors.notes).toBe(`Notes must be ${NOTES_MAX_LENGTH} characters or fewer.`);
+  });
+
+  test('rejects a non-integer round count adjustment', () => {
+    const result = validateMaintenanceInput({ ...VALID, round_count_delta: 1.5 });
+    expect(result.fieldErrors.round_count_delta).toBe('Round count adjustment must be a whole number.');
+  });
+
+  test('rejects a round count adjustment outside the allowed range', () => {
+    const result = validateMaintenanceInput({ ...VALID, round_count_delta: MAX_ROUND_COUNT_DELTA + 1 });
+    expect(result.isValid).toBe(false);
+    expect(validateMaintenanceInput({ ...VALID, round_count_delta: -MAX_ROUND_COUNT_DELTA }).isValid).toBe(true);
+  });
+});

--- a/tests/unit/photos.repository.test.js
+++ b/tests/unit/photos.repository.test.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createDbClient } = require('../../src/infra/db/client');
+const { migrate } = require('../../src/infra/db/migrate');
+const { createFirearmsRepository } = require('../../src/infra/db/repositories/firearms.repository');
+const { createPhotosRepository } = require('../../src/infra/db/repositories/photos.repository');
+
+const MINIMAL_FIREARM = {
+  make: 'Glock',
+  model: '19',
+  serial: '',
+  caliber: '9mm',
+  purchase_date: '2024-01-01',
+  purchase_price: 500,
+  condition: 'New',
+  location: 'Safe',
+  status: 'Active',
+  notes: '',
+  gun_warranty: 0,
+  firearm_type: 'Pistol'
+};
+
+function photoRow(overrides = {}) {
+  return {
+    firearm_id: 1,
+    filename: `${'a'.repeat(32)}.jpg`,
+    original_name: 'my-pistol.jpg',
+    mime: 'image/jpeg',
+    size: 1024,
+    ...overrides
+  };
+}
+
+describe('photos repository', () => {
+  let db;
+  let dbPath;
+  let firearmsRepo;
+  let photosRepo;
+  let firearmId;
+
+  beforeEach(() => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-photos-'));
+    dbPath = path.join(tempDir, 'app.db');
+    db = createDbClient(dbPath);
+    migrate(db);
+    firearmsRepo = createFirearmsRepository(db);
+    photosRepo = createPhotosRepository(db);
+    firearmId = firearmsRepo.create({ ...MINIMAL_FIREARM });
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  test('create returns the new id and listByFirearm returns rows in insertion order', () => {
+    const first = photosRepo.create(photoRow({ firearm_id: firearmId, filename: `${'a'.repeat(32)}.jpg` }));
+    const second = photosRepo.create(photoRow({ firearm_id: firearmId, filename: `${'b'.repeat(32)}.png`, mime: 'image/png' }));
+
+    const rows = photosRepo.listByFirearm(firearmId);
+    expect(rows.map((r) => r.id)).toEqual([first, second]);
+    expect(rows[0].original_name).toBe('my-pistol.jpg');
+    expect(rows[1].mime).toBe('image/png');
+  });
+
+  test('countForFirearm counts only that firearm', () => {
+    const otherFirearmId = firearmsRepo.create({ ...MINIMAL_FIREARM, make: 'Sig', model: 'P320' });
+    photosRepo.create(photoRow({ firearm_id: firearmId, filename: `${'a'.repeat(32)}.jpg` }));
+    photosRepo.create(photoRow({ firearm_id: otherFirearmId, filename: `${'b'.repeat(32)}.jpg` }));
+
+    expect(photosRepo.countForFirearm(firearmId)).toBe(1);
+    expect(photosRepo.countForFirearm(otherFirearmId)).toBe(1);
+  });
+
+  test('get and remove are scoped to the firearm', () => {
+    const otherFirearmId = firearmsRepo.create({ ...MINIMAL_FIREARM, make: 'Sig', model: 'P320' });
+    const photoId = photosRepo.create(photoRow({ firearm_id: firearmId }));
+
+    expect(photosRepo.get(photoId, firearmId)).toBeTruthy();
+    expect(photosRepo.get(photoId, otherFirearmId)).toBeUndefined();
+
+    photosRepo.remove(photoId, otherFirearmId);
+    expect(photosRepo.get(photoId, firearmId)).toBeTruthy();
+
+    photosRepo.remove(photoId, firearmId);
+    expect(photosRepo.get(photoId, firearmId)).toBeUndefined();
+  });
+
+  test('rejects duplicate filenames', () => {
+    photosRepo.create(photoRow({ firearm_id: firearmId }));
+
+    expect(() => photosRepo.create(photoRow({ firearm_id: firearmId }))).toThrow(/UNIQUE/);
+  });
+
+  test('removeByFirearm deletes all rows for the firearm', () => {
+    photosRepo.create(photoRow({ firearm_id: firearmId, filename: `${'a'.repeat(32)}.jpg` }));
+    photosRepo.create(photoRow({ firearm_id: firearmId, filename: `${'b'.repeat(32)}.jpg` }));
+
+    photosRepo.removeByFirearm(firearmId);
+
+    expect(photosRepo.countForFirearm(firearmId)).toBe(0);
+  });
+
+  test('deleting a firearm cascades to its photo rows', () => {
+    const photoId = photosRepo.create(photoRow({ firearm_id: firearmId }));
+
+    firearmsRepo.remove(firearmId, 1);
+
+    expect(photosRepo.get(photoId, firearmId)).toBeUndefined();
+  });
+});

--- a/tests/unit/photos.repository.test.js
+++ b/tests/unit/photos.repository.test.js
@@ -94,6 +94,17 @@ describe('photos repository', () => {
     expect(() => photosRepo.create(photoRow({ firearm_id: firearmId }))).toThrow(/UNIQUE/);
   });
 
+  test('createIfUnderCap inserts below the cap and returns null at the cap', () => {
+    const first = photosRepo.createIfUnderCap(photoRow({ firearm_id: firearmId, filename: `${'a'.repeat(32)}.jpg` }), 2);
+    const second = photosRepo.createIfUnderCap(photoRow({ firearm_id: firearmId, filename: `${'b'.repeat(32)}.jpg` }), 2);
+    const third = photosRepo.createIfUnderCap(photoRow({ firearm_id: firearmId, filename: `${'c'.repeat(32)}.jpg` }), 2);
+
+    expect(first).toBeGreaterThan(0);
+    expect(second).toBeGreaterThan(first);
+    expect(third).toBeNull();
+    expect(photosRepo.countForFirearm(firearmId)).toBe(2);
+  });
+
   test('removeByFirearm deletes all rows for the firearm', () => {
     photosRepo.create(photoRow({ firearm_id: firearmId, filename: `${'a'.repeat(32)}.jpg` }));
     photosRepo.create(photoRow({ firearm_id: firearmId, filename: `${'b'.repeat(32)}.jpg` }));

--- a/tests/unit/photos.service.test.js
+++ b/tests/unit/photos.service.test.js
@@ -29,7 +29,7 @@ describe('photos service', () => {
       listByFirearm: jest.fn(() => []),
       get: jest.fn(),
       countForFirearm: jest.fn(() => 0),
-      create: jest.fn(() => 5),
+      createIfUnderCap: jest.fn(() => 5),
       remove: jest.fn(),
       removeByFirearm: jest.fn()
     };
@@ -47,13 +47,16 @@ describe('photos service', () => {
       expect(result.id).toBe(5);
       expect(result.filename).toMatch(/^[a-f0-9]{32}\.jpg$/);
       expect(fs.readFileSync(path.join(photosDir, result.filename), 'utf8')).toBe('fake image bytes');
-      expect(photosRepository.create).toHaveBeenCalledWith({
-        firearm_id: 3,
-        filename: result.filename,
-        original_name: 'range-day.jpg',
-        mime: 'image/jpeg',
-        size: fakeFile().size
-      });
+      expect(photosRepository.createIfUnderCap).toHaveBeenCalledWith(
+        {
+          firearm_id: 3,
+          filename: result.filename,
+          original_name: 'range-day.jpg',
+          mime: 'image/jpeg',
+          size: fakeFile().size
+        },
+        MAX_PHOTOS_PER_FIREARM
+      );
     });
 
     test('derives the extension from the mime type, not the client filename', async () => {
@@ -66,7 +69,7 @@ describe('photos service', () => {
       await expect(service.storePhoto(3, fakeFile({ mimetype: 'text/plain' }))).rejects.toMatchObject({
         code: 'INVALID_FILE_TYPE'
       });
-      expect(photosRepository.create).not.toHaveBeenCalled();
+      expect(photosRepository.createIfUnderCap).not.toHaveBeenCalled();
     });
 
     test('rejects an upload past the per-firearm cap', async () => {
@@ -76,8 +79,15 @@ describe('photos service', () => {
       expect(fs.readdirSync(photosDir)).toHaveLength(0);
     });
 
+    test('removes the file when a concurrent upload takes the last cap slot', async () => {
+      photosRepository.createIfUnderCap.mockReturnValue(null);
+
+      await expect(service.storePhoto(3, fakeFile())).rejects.toMatchObject({ code: 'PHOTO_LIMIT' });
+      expect(fs.readdirSync(photosDir)).toHaveLength(0);
+    });
+
     test('removes the written file when the insert fails', async () => {
-      photosRepository.create.mockImplementation(() => {
+      photosRepository.createIfUnderCap.mockImplementation(() => {
         throw new Error('UNIQUE constraint failed');
       });
 

--- a/tests/unit/photos.service.test.js
+++ b/tests/unit/photos.service.test.js
@@ -41,8 +41,8 @@ describe('photos service', () => {
   });
 
   describe('storePhoto', () => {
-    test('writes the file with a generated name and records the row', () => {
-      const result = service.storePhoto(3, fakeFile());
+    test('writes the file with a generated name and records the row', async () => {
+      const result = await service.storePhoto(3, fakeFile());
 
       expect(result.id).toBe(5);
       expect(result.filename).toMatch(/^[a-f0-9]{32}\.jpg$/);
@@ -56,34 +56,32 @@ describe('photos service', () => {
       });
     });
 
-    test('derives the extension from the mime type, not the client filename', () => {
-      const result = service.storePhoto(3, fakeFile({ originalname: 'sneaky.exe', mimetype: 'image/png' }));
+    test('derives the extension from the mime type, not the client filename', async () => {
+      const result = await service.storePhoto(3, fakeFile({ originalname: 'sneaky.exe', mimetype: 'image/png' }));
 
       expect(result.filename).toMatch(/^[a-f0-9]{32}\.png$/);
     });
 
-    test('rejects a disallowed mime type', () => {
-      expect(() => service.storePhoto(3, fakeFile({ mimetype: 'text/plain' }))).toThrow(
-        expect.objectContaining({ code: 'INVALID_FILE_TYPE' })
-      );
+    test('rejects a disallowed mime type', async () => {
+      await expect(service.storePhoto(3, fakeFile({ mimetype: 'text/plain' }))).rejects.toMatchObject({
+        code: 'INVALID_FILE_TYPE'
+      });
       expect(photosRepository.create).not.toHaveBeenCalled();
     });
 
-    test('rejects an upload past the per-firearm cap', () => {
+    test('rejects an upload past the per-firearm cap', async () => {
       photosRepository.countForFirearm.mockReturnValue(MAX_PHOTOS_PER_FIREARM);
 
-      expect(() => service.storePhoto(3, fakeFile())).toThrow(
-        expect.objectContaining({ code: 'PHOTO_LIMIT' })
-      );
+      await expect(service.storePhoto(3, fakeFile())).rejects.toMatchObject({ code: 'PHOTO_LIMIT' });
       expect(fs.readdirSync(photosDir)).toHaveLength(0);
     });
 
-    test('removes the written file when the insert fails', () => {
+    test('removes the written file when the insert fails', async () => {
       photosRepository.create.mockImplementation(() => {
         throw new Error('UNIQUE constraint failed');
       });
 
-      expect(() => service.storePhoto(3, fakeFile())).toThrow('UNIQUE constraint failed');
+      await expect(service.storePhoto(3, fakeFile())).rejects.toThrow('UNIQUE constraint failed');
       expect(fs.readdirSync(photosDir)).toHaveLength(0);
     });
   });

--- a/tests/unit/photos.service.test.js
+++ b/tests/unit/photos.service.test.js
@@ -109,6 +109,16 @@ describe('photos service', () => {
       expect(service.removePhoto(9, 3)).toBe(false);
       expect(photosRepository.remove).not.toHaveBeenCalled();
     });
+
+    test('keeps the row when the unlink fails with a real error', () => {
+      photosRepository.get.mockReturnValue({ id: 9, firearm_id: 3, filename: `${'a'.repeat(32)}.jpg` });
+      jest.spyOn(fs, 'unlinkSync').mockImplementation(() => {
+        throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' });
+      });
+
+      expect(() => service.removePhoto(9, 3)).toThrow('operation not permitted');
+      expect(photosRepository.remove).not.toHaveBeenCalled();
+    });
   });
 
   describe('removeAllForFirearm', () => {

--- a/tests/unit/photos.service.test.js
+++ b/tests/unit/photos.service.test.js
@@ -1,0 +1,129 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  createPhotosService,
+  MAX_PHOTOS_PER_FIREARM
+} = require('../../src/features/photos/photos.service');
+
+function fakeFile(overrides = {}) {
+  const buffer = Buffer.from('fake image bytes');
+  return {
+    originalname: 'range-day.jpg',
+    mimetype: 'image/jpeg',
+    size: buffer.length,
+    buffer,
+    ...overrides
+  };
+}
+
+describe('photos service', () => {
+  let photosDir;
+  let photosRepository;
+  let service;
+
+  beforeEach(() => {
+    photosDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-photos-svc-'));
+    photosRepository = {
+      listByFirearm: jest.fn(() => []),
+      get: jest.fn(),
+      countForFirearm: jest.fn(() => 0),
+      create: jest.fn(() => 5),
+      remove: jest.fn(),
+      removeByFirearm: jest.fn()
+    };
+    service = createPhotosService({ photosRepository, photosDir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(photosDir, { recursive: true, force: true });
+  });
+
+  describe('storePhoto', () => {
+    test('writes the file with a generated name and records the row', () => {
+      const result = service.storePhoto(3, fakeFile());
+
+      expect(result.id).toBe(5);
+      expect(result.filename).toMatch(/^[a-f0-9]{32}\.jpg$/);
+      expect(fs.readFileSync(path.join(photosDir, result.filename), 'utf8')).toBe('fake image bytes');
+      expect(photosRepository.create).toHaveBeenCalledWith({
+        firearm_id: 3,
+        filename: result.filename,
+        original_name: 'range-day.jpg',
+        mime: 'image/jpeg',
+        size: fakeFile().size
+      });
+    });
+
+    test('derives the extension from the mime type, not the client filename', () => {
+      const result = service.storePhoto(3, fakeFile({ originalname: 'sneaky.exe', mimetype: 'image/png' }));
+
+      expect(result.filename).toMatch(/^[a-f0-9]{32}\.png$/);
+    });
+
+    test('rejects a disallowed mime type', () => {
+      expect(() => service.storePhoto(3, fakeFile({ mimetype: 'text/plain' }))).toThrow(
+        expect.objectContaining({ code: 'INVALID_FILE_TYPE' })
+      );
+      expect(photosRepository.create).not.toHaveBeenCalled();
+    });
+
+    test('rejects an upload past the per-firearm cap', () => {
+      photosRepository.countForFirearm.mockReturnValue(MAX_PHOTOS_PER_FIREARM);
+
+      expect(() => service.storePhoto(3, fakeFile())).toThrow(
+        expect.objectContaining({ code: 'PHOTO_LIMIT' })
+      );
+      expect(fs.readdirSync(photosDir)).toHaveLength(0);
+    });
+
+    test('removes the written file when the insert fails', () => {
+      photosRepository.create.mockImplementation(() => {
+        throw new Error('UNIQUE constraint failed');
+      });
+
+      expect(() => service.storePhoto(3, fakeFile())).toThrow('UNIQUE constraint failed');
+      expect(fs.readdirSync(photosDir)).toHaveLength(0);
+    });
+  });
+
+  describe('removePhoto', () => {
+    test('deletes the row and the file', () => {
+      const filename = `${'c'.repeat(32)}.jpg`;
+      fs.writeFileSync(path.join(photosDir, filename), 'bytes');
+      photosRepository.get.mockReturnValue({ id: 9, firearm_id: 3, filename });
+
+      expect(service.removePhoto(9, 3)).toBe(true);
+      expect(photosRepository.remove).toHaveBeenCalledWith(9, 3);
+      expect(fs.existsSync(path.join(photosDir, filename))).toBe(false);
+    });
+
+    test('tolerates a file that is already gone', () => {
+      photosRepository.get.mockReturnValue({ id: 9, firearm_id: 3, filename: `${'d'.repeat(32)}.jpg` });
+
+      expect(service.removePhoto(9, 3)).toBe(true);
+    });
+
+    test('returns false for an unknown photo', () => {
+      photosRepository.get.mockReturnValue(undefined);
+
+      expect(service.removePhoto(9, 3)).toBe(false);
+      expect(photosRepository.remove).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('removeAllForFirearm', () => {
+    test('unlinks every file and clears the rows', () => {
+      const filenames = [`${'e'.repeat(32)}.jpg`, `${'f'.repeat(32)}.png`];
+      for (const filename of filenames) {
+        fs.writeFileSync(path.join(photosDir, filename), 'bytes');
+      }
+      photosRepository.listByFirearm.mockReturnValue(filenames.map((filename, index) => ({ id: index + 1, filename })));
+
+      expect(service.removeAllForFirearm(3)).toBe(2);
+      expect(fs.readdirSync(photosDir)).toHaveLength(0);
+      expect(photosRepository.removeByFirearm).toHaveBeenCalledWith(3);
+    });
+  });
+});

--- a/tests/unit/range-sessions.repository.test.js
+++ b/tests/unit/range-sessions.repository.test.js
@@ -1,0 +1,97 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { createDbClient } = require('../../src/infra/db/client');
+const { migrate } = require('../../src/infra/db/migrate');
+const { createFirearmsRepository } = require('../../src/infra/db/repositories/firearms.repository');
+const { createRangeSessionsRepository } = require('../../src/infra/db/repositories/range-sessions.repository');
+
+const MINIMAL_FIREARM = {
+  make: 'Glock',
+  model: '19',
+  serial: '',
+  caliber: '9mm',
+  purchase_date: '2024-01-01',
+  purchase_price: 500,
+  condition: 'New',
+  location: 'Safe',
+  status: 'Active',
+  notes: '',
+  gun_warranty: 0,
+  firearm_type: 'Pistol'
+};
+
+describe('range sessions repository', () => {
+  let db;
+  let dbPath;
+  let firearmsRepo;
+  let rangeSessionsRepo;
+  let firearmId;
+
+  beforeEach(() => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ppcollection-range-'));
+    dbPath = path.join(tempDir, 'app.db');
+    db = createDbClient(dbPath);
+    migrate(db);
+    firearmsRepo = createFirearmsRepository(db);
+    rangeSessionsRepo = createRangeSessionsRepository(db);
+    firearmId = firearmsRepo.create({ ...MINIMAL_FIREARM });
+  });
+
+  afterEach(() => {
+    db.close();
+    fs.rmSync(path.dirname(dbPath), { recursive: true, force: true });
+  });
+
+  test('create returns the new id and listByFirearm orders by date descending', () => {
+    rangeSessionsRepo.create({ firearm_id: firearmId, date: '2025-01-01', location: 'Indoor Range', rounds_fired: 100 });
+    rangeSessionsRepo.create({ firearm_id: firearmId, date: '2025-05-01', rounds_fired: 50, notes: 'Windy' });
+
+    const rows = rangeSessionsRepo.listByFirearm(firearmId);
+    expect(rows.map((r) => r.date)).toEqual(['2025-05-01', '2025-01-01']);
+    expect(rows[0].notes).toBe('Windy');
+    expect(rows[0].location).toBe('');
+    expect(rows[1].location).toBe('Indoor Range');
+  });
+
+  test('get and remove are scoped to the firearm', () => {
+    const otherFirearmId = firearmsRepo.create({ ...MINIMAL_FIREARM, make: 'Sig', model: 'P320' });
+    const sessionId = rangeSessionsRepo.create({ firearm_id: firearmId, date: '2025-02-02' });
+
+    expect(rangeSessionsRepo.get(sessionId, firearmId)).toBeTruthy();
+    expect(rangeSessionsRepo.get(sessionId, otherFirearmId)).toBeUndefined();
+
+    rangeSessionsRepo.remove(sessionId, otherFirearmId);
+    expect(rangeSessionsRepo.get(sessionId, firearmId)).toBeTruthy();
+
+    rangeSessionsRepo.remove(sessionId, firearmId);
+    expect(rangeSessionsRepo.get(sessionId, firearmId)).toBeUndefined();
+  });
+
+  test('totalsForFirearm sums rounds and treats missing counts as zero', () => {
+    rangeSessionsRepo.create({ firearm_id: firearmId, date: '2025-01-01', rounds_fired: 100 });
+    rangeSessionsRepo.create({ firearm_id: firearmId, date: '2025-02-01', rounds_fired: null });
+    rangeSessionsRepo.create({ firearm_id: firearmId, date: '2025-03-01', rounds_fired: 50 });
+
+    expect(rangeSessionsRepo.totalsForFirearm(firearmId)).toEqual({
+      session_count: 3,
+      total_rounds: 150
+    });
+  });
+
+  test('totalsForFirearm returns zeros when nothing is logged', () => {
+    expect(rangeSessionsRepo.totalsForFirearm(firearmId)).toEqual({
+      session_count: 0,
+      total_rounds: 0
+    });
+  });
+
+  test('deleting a firearm cascades to its range sessions', () => {
+    const sessionId = rangeSessionsRepo.create({ firearm_id: firearmId, date: '2025-01-01' });
+
+    firearmsRepo.remove(firearmId, 1);
+
+    expect(rangeSessionsRepo.get(sessionId, firearmId)).toBeUndefined();
+  });
+});

--- a/tests/unit/range-sessions.service.test.js
+++ b/tests/unit/range-sessions.service.test.js
@@ -1,0 +1,42 @@
+const { createRangeSessionsService } = require('../../src/features/range-sessions/range-sessions.service');
+
+describe('range sessions service', () => {
+  let rangeSessionsRepository;
+  let service;
+
+  beforeEach(() => {
+    rangeSessionsRepository = {
+      listByFirearm: jest.fn(() => []),
+      get: jest.fn(),
+      create: jest.fn(() => 11),
+      remove: jest.fn(),
+      totalsForFirearm: jest.fn(() => ({ session_count: 2, total_rounds: 300 }))
+    };
+    service = createRangeSessionsService(rangeSessionsRepository);
+  });
+
+  test('create attaches the firearm id and returns the new row id', () => {
+    const id = service.create(4, { date: '2025-01-01', location: '', rounds_fired: 100, notes: '' });
+
+    expect(id).toBe(11);
+    expect(rangeSessionsRepository.create).toHaveBeenCalledWith({
+      firearm_id: 4,
+      date: '2025-01-01',
+      location: '',
+      rounds_fired: 100,
+      notes: ''
+    });
+  });
+
+  test('listByFirearm, get, remove, and totalsForFirearm delegate to the repository', () => {
+    service.listByFirearm(4);
+    service.get(9, 4);
+    service.remove(9, 4);
+
+    expect(service.totalsForFirearm(4)).toEqual({ session_count: 2, total_rounds: 300 });
+    expect(rangeSessionsRepository.listByFirearm).toHaveBeenCalledWith(4);
+    expect(rangeSessionsRepository.get).toHaveBeenCalledWith(9, 4);
+    expect(rangeSessionsRepository.remove).toHaveBeenCalledWith(9, 4);
+    expect(rangeSessionsRepository.totalsForFirearm).toHaveBeenCalledWith(4);
+  });
+});

--- a/tests/unit/range-sessions.validators.test.js
+++ b/tests/unit/range-sessions.validators.test.js
@@ -1,0 +1,84 @@
+const {
+  sanitizeRangeSessionInput,
+  validateRangeSessionInput,
+  LOCATION_MAX_LENGTH,
+  NOTES_MAX_LENGTH,
+  MAX_ROUNDS_FIRED
+} = require('../../src/features/range-sessions/range-sessions.validators');
+
+describe('sanitizeRangeSessionInput', () => {
+  test('trims strings and converts an empty rounds count to null', () => {
+    const result = sanitizeRangeSessionInput({
+      date: ' 2025-06-01 ',
+      location: ' Indoor Range ',
+      rounds_fired: '',
+      notes: ' Good session '
+    });
+
+    expect(result).toEqual({
+      date: '2025-06-01',
+      location: 'Indoor Range',
+      rounds_fired: null,
+      notes: 'Good session'
+    });
+  });
+
+  test('converts a numeric rounds string to a number', () => {
+    expect(sanitizeRangeSessionInput({ rounds_fired: '200' }).rounds_fired).toBe(200);
+  });
+
+  test('defaults missing fields to empty values', () => {
+    expect(sanitizeRangeSessionInput({})).toEqual({
+      date: '',
+      location: '',
+      rounds_fired: null,
+      notes: ''
+    });
+  });
+});
+
+describe('validateRangeSessionInput', () => {
+  const VALID = { date: '2025-06-01', location: 'Outdoor Range', rounds_fired: 150, notes: '' };
+
+  test('accepts a valid session', () => {
+    expect(validateRangeSessionInput(VALID)).toEqual({ isValid: true, fieldErrors: {} });
+  });
+
+  test('accepts optional fields left empty', () => {
+    expect(validateRangeSessionInput({ ...VALID, location: '', rounds_fired: null }).isValid).toBe(true);
+  });
+
+  test('requires a date', () => {
+    const result = validateRangeSessionInput({ ...VALID, date: '' });
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.date).toBe('Date is required.');
+  });
+
+  test.each(['2025-02-30', '06/01/2025', 'soon'])('rejects malformed date %s', (date) => {
+    const result = validateRangeSessionInput({ ...VALID, date });
+    expect(result.fieldErrors.date).toBe('Date must be a valid date in YYYY-MM-DD format.');
+  });
+
+  test('rejects a location over the limit', () => {
+    const result = validateRangeSessionInput({ ...VALID, location: 'x'.repeat(LOCATION_MAX_LENGTH + 1) });
+    expect(result.fieldErrors.location).toBe(`Location must be ${LOCATION_MAX_LENGTH} characters or fewer.`);
+  });
+
+  test('rejects notes over the limit', () => {
+    const result = validateRangeSessionInput({ ...VALID, notes: 'x'.repeat(NOTES_MAX_LENGTH + 1) });
+    expect(result.fieldErrors.notes).toBe(`Notes must be ${NOTES_MAX_LENGTH} characters or fewer.`);
+  });
+
+  test('rejects invalid rounds fired values', () => {
+    expect(validateRangeSessionInput({ ...VALID, rounds_fired: 1.5 }).fieldErrors.rounds_fired).toBe(
+      'Rounds fired must be a whole number.'
+    );
+    expect(validateRangeSessionInput({ ...VALID, rounds_fired: -1 }).fieldErrors.rounds_fired).toBe(
+      'Rounds fired cannot be negative.'
+    );
+    expect(validateRangeSessionInput({ ...VALID, rounds_fired: MAX_ROUNDS_FIRED + 1 }).fieldErrors.rounds_fired).toBe(
+      `Rounds fired must be ${MAX_ROUNDS_FIRED} or less.`
+    );
+    expect(validateRangeSessionInput({ ...VALID, rounds_fired: MAX_ROUNDS_FIRED }).isValid).toBe(true);
+  });
+});

--- a/wiki/Architecture.md
+++ b/wiki/Architecture.md
@@ -72,9 +72,14 @@ src/
 - The migration runner records applied files in a `schema_migrations` table;
   shipped migrations are immutable.
 - `settings` is a key/value table holding `username`, `password_hash`,
-  `must_change_password`, `theme`, `update_check_enabled`.
-- `maintenance_logs` and `range_sessions` tables exist in the initial schema
-  but have no UI yet — intentional, reserved for future features.
+  `must_change_password`, `theme`, `update_check_enabled`,
+  `maintenance_due_days`.
+- `maintenance_logs` and `range_sessions` back the maintenance log and range
+  session sections on the firearm detail page; ownership is checked through
+  the parent firearm (neither table has a `user_id` column).
+- `firearm_photos` (migration `007`) stores photo metadata; image files live
+  under `<dataDir>/photos` with server-generated filenames and are served
+  only through an authenticated, ownership-checked route.
 
 ## Technology stack
 


### PR DESCRIPTION
Implements the three open feature issues in three conventional commits (one per issue):

Closes #149
Closes #151
Closes #152

## Maintenance Tracking (#149) — `feat(maintenance)`

- Per-firearm maintenance log (date, type, notes, round count adjustment) as a new section on the firearm detail page, backed by the existing `maintenance_logs` table. Add via a no-JS `<details>` form; delete per row.
- **Due-for-cleaning reminder**: a firearm is flagged when its last `Cleaning` entry is older than a configurable threshold **or** a range session is newer than the last cleaning (including fired-but-never-cleaned). Disposed firearms are never flagged.
- The threshold is user-editable on Profile → Preferences (settings key `maintenance_due_days`, 1–365, default 90).
- Surfaced as a badge + reason on the detail page, and a "Due for cleaning" stat card plus a top-5 due list on the home dashboard.

## Range Sessions (#151) — `feat(range-sessions)`

- Per-firearm session log (date, location, rounds fired, notes) on the detail page, backed by the existing `range_sessions` table, with a per-firearm "N sessions · M rounds" summary.
- Range activity feeds the cleaning-due rule above.

## Photo Attachments (#152) — `feat(photos)`

- Photo gallery with AJAX upload and per-photo delete on the firearm detail page.
- New `firearm_photos` table (migration `007`) holds metadata only; files are written to `<dataDir>/photos` (Docker: `/data/photos`) with server-generated random hex filenames, so backing up `/data` captures the database and photos together. Works with the read-only-rootfs compose setup.
- Uploads: `multer` 2.x memory storage, 10 MB cap, JPEG/PNG/WebP/GIF only, max 12 photos per firearm. The CSRF token travels in the `x-csrf-token` header because multipart bodies are parsed after the CSRF check.
- Serving: authenticated, ownership-checked route only (`res.sendFile` with `root:` containment + filename pattern check); the photos directory is never mounted as static.
- Deleting a photo or its firearm unlinks the files on disk (the DB cascade only removes rows).

## Architecture

Three new feature folders (`maintenance/`, `range-sessions/`, `photos/`) following the existing routes → controller → service → repository layering, mounted on the `/firearms` prefix with nested `/:firearmId/...` paths. `firearms.controller.show()` composes the new sections via optional injected services, so each commit stands alone.

## Testing

- 54 new tests (31 suites, 304 total, all passing): unit tests for each repository/validator/service (real temp SQLite for repos, mocked deps for services) and integration suites for each feature, including multipart upload via Supertest `.attach()` with the CSRF header, upload caps, ownership 404s, and file-cleanup-on-delete assertions.
- Coverage: 95.6% statements / 80.2% branches / 96.0% functions / 96.1% lines (gates: 90/75/90/90).
- `npm run lint` clean; server boot smoke-tested (migration 007 applies, photos dir auto-created).

Docs updated: README (features + backup note), `docs/architecture.md`, `wiki/Architecture.md`, `CLAUDE.md` (tree, DB section, `DATA_DIR` env row, backlog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HDtYzjbRKZ3Y49jQCaE8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_013HDtYzjbRKZ3Y49jQCaE8Z)_