### PR TITLE
fix(docker): bump base image for openssl/musl/zlib patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_IMAGE=node:22.20.0-alpine3.22@sha256:dbcedd8aeab47fbc0f4dd4bffa55b7c3c729a707875968d467aaaea42d6225af
+ARG NODE_IMAGE=node:22.22.3-alpine3.22@sha256:cd7807368cf24826297cbad5dca1a44972ccfd770647db52a8c7589eb4599ac8
 
 FROM ${NODE_IMAGE} AS deps
 


### PR DESCRIPTION
## Problem

The `2.4.0` Release workflow ([run 29861170971](https://github.com/Gogorichielab/PPCollection/actions/runs/29861170971)) failed at **Trivy - scan built image**, so the versioned Docker image was never pushed to GHCR (the tag and GitHub release exist; only the image publish was blocked).

## Root cause

The scan flagged **fixable HIGH** CVEs in the Alpine base-image OS layer — not in app code or dependencies (verified: `npm audit --omit=dev` and a full OSV.dev query across all 124 production packages both return zero):

| Package | CVE(s) | Fixed in |
|---|---|---|
| openssl / libcrypto3 / libssl3 | CVE-2026-45447 (+ CVE-2025-15467, CVE-2025-69421, CVE-2026-28387…28390) | 3.5.7-r0 |
| musl / musl-utils | CVE-2026-40200 | 1.2.5-r12 |
| zlib | CVE-2026-22184 | 1.3.2-r0 |

These are brand-new (2026) CVEs. At build time the patched Alpine packages had not yet propagated, so `apk upgrade` couldn't pull them. Re-running the job alone did **not** help: with the base digest unchanged, buildx reused the cached `apk upgrade` layer (the rebuild's "Build local release candidate" step took ~11s — fully cached), so the patches were never re-fetched.

## Fix

Bump the pinned base image from `node:22.20.0-alpine3.22` to `node:22.22.3-alpine3.22` (`sha256:cd7807…`, Alpine 3.22.4). The new digest:

- **Busts the buildx cache** for every downstream `RUN` layer, so `apk upgrade --no-cache` re-executes and pulls the current patched packages.
- Starts from a base that **already ships** the patched musl (1.2.5-r12) and zlib (1.3.2-r0); only openssl is one patch behind (3.5.6-r0), which `apk upgrade` lifts to 3.5.7-r0 (confirmed available in the Alpine 3.22 repo for both amd64 and arm64).

Verified by pulling and scanning the new base with Trivy locally. Merging this cuts a `2.4.1` patch release, whose image build starts fresh from the new base and clears the scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HDtYzjbRKZ3Y49jQCaE8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_013HDtYzjbRKZ3Y49jQCaE8Z)_