### PR TITLE
fix(docker): drop bundled npm from the runtime image to clear image CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,13 @@ ENV NODE_ENV=production \
 
 EXPOSE 3000
 
+# The app runs `node src/server.js` directly, so the bundled npm/corepack
+# are not needed at runtime. Removing them drops their vulnerable transitive
+# deps (tar, sigstore, brace-expansion, picomatch, …) from the image so the
+# Trivy image scan stays clean and the attack surface is smaller.
 RUN apk upgrade --no-cache \
+  && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx \
+       /usr/local/lib/node_modules/corepack /usr/local/bin/corepack \
   && mkdir -p /data \
   && chown -R node:node /data \
   && chown -R node:node /app
@@ -43,4 +49,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||3000)+'/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
 USER node
-CMD ["npm", "start"]
+CMD ["node", "src/server.js"]


### PR DESCRIPTION
## Why the release keeps failing

The `2.4.0`/`2.4.1`/`2.4.2` Release builds all failed at **Trivy - scan built image**, so no Docker image was published. I reproduced the exact release image locally and scanned it with the workflow's settings (`HIGH,CRITICAL`, `--ignore-unfixed`, `--pkg-types os,library`). The real findings are **in the npm CLI bundled inside the node base image** (`/usr/local/lib/node_modules/npm/...`), not our app or the OS layer:

| Package | CVE | Severity |
|---|---|---|
| tar 7.5.11 | CVE-2026-59873 (gzip-bomb DoS) | **CRITICAL** |
| tar 7.5.11 | CVE-2026-59874 | HIGH |
| sigstore 3.1.0 | CVE-2026-48815 | HIGH |
| brace-expansion 2.0.2 | CVE-2026-13149 | HIGH |
| picomatch 4.0.3 | CVE-2026-33671 | HIGH |

Our own dependencies are clean (`npm audit --omit=dev` and a full OSV.dev query over all 124 production packages return zero). These CVEs live in **node's bundled npm**, which `apk upgrade` doesn't manage and a base-image digest bump doesn't remove — which is why earlier attempts didn't help.

## Fix

The container's start command is `node src/server.js` (the `package.json` start script), so npm/npx/corepack are **not used at runtime**. Removing them from the final stage drops all their vulnerable transitive deps, clears the image scan, and shrinks the runtime attack surface. `CMD` is switched from `["npm", "start"]` to `["node", "src/server.js"]` (functionally identical).

## Verification (local)

Built the real image and scanned with the release settings:
- **Before:** 5 findings (1 CRITICAL, 4 HIGH) under bundled npm.
- **After:** `Total: 0` across os + library.
- Container still boots and serves `/health` (`{"status":"ok"}`); confirmed `npm` is absent from the image.

Merging cuts a patch release whose image build passes the Trivy gate and publishes to GHCR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HDtYzjbRKZ3Y49jQCaE8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_013HDtYzjbRKZ3Y49jQCaE8Z)_